### PR TITLE
Bookkeeping fields: isCached, isCheckpointed; related methods: unpersist(), checkpoint().

### DIFF
--- a/pkg/NAMESPACE
+++ b/pkg/NAMESPACE
@@ -26,5 +26,13 @@ exportMethods(
              )
 
 # S3 methods exported
-export("textFile", "parallelize", "hashCode", "includePackage", "broadcast", "setBroadcastValue")
+export(
+       "textFile",
+       "parallelize",
+       "hashCode",
+       "includePackage",
+       "broadcast",
+       "setBroadcastValue",
+       "setCheckpointDir"
+      )
 export("sparkR.init")

--- a/pkg/R/RDD.R
+++ b/pkg/R/RDD.R
@@ -18,10 +18,9 @@ setClass("RDD",
                       serialized = "logical"))
 
 setMethod("initialize", "RDD", function(.Object, jrdd, serialized, isCached, isCheckpointed) {
-  # We use an environment to store mutable states inside an RDD object (currently
-  # only `isCached'). Note that R's call-by-value semantics makes modifying slots
-  # inside an object (passed as an argument into a function, such as cache())
-  # difficult.
+  # We use an environment to store mutable states inside an RDD object. Note
+  # that R's call-by-value semantics makes modifying slots inside an object
+  # (passed as an argument into a function, such as cache()) difficult.
   .Object@env <- new.env()
   .Object@env$isCached <- isCached
   .Object@env$isCheckpointed <- isCheckpointed
@@ -104,11 +103,10 @@ setMethod("unpersist",
 #' Checkpoint an RDD
 #'
 #' Mark this RDD for checkpointing. It will be saved to a file inside the
-#' checkpoint directory set with SparkContext.setCheckpointDir() and all
-#' references to its parent RDDs will be removed. This function must be called
-#' before any job has been executed on this RDD. It is strongly recommended that
-#' this RDD is persisted in memory, otherwise saving it on a file will require
-#' recomputation.
+#' checkpoint directory set with setCheckpointDir() and all references to its
+#' parent RDDs will be removed. This function must be called before any job has
+#' been executed on this RDD. It is strongly recommended that this RDD is
+#' persisted in memory, otherwise saving it on a file will require recomputation.
 #'
 #' @param rdd The RDD to checkpoint
 #' @rdname checkpoint-methods
@@ -116,6 +114,7 @@ setMethod("unpersist",
 #' @examples
 #'\dontrun{
 #' sc <- sparkR.init()
+#' setCheckpointDir(sc, "checkpoints")
 #' rdd <- parallelize(sc, 1:10, 2L)
 #' checkpoint(rdd)
 #'}

--- a/pkg/R/context.R
+++ b/pkg/R/context.R
@@ -122,13 +122,13 @@ includePackage <- function(sc, pkg) {
   .sparkREnv[[".packages"]] <- packages
 }
 
-#' @title Broadcast a variable to all workers 
-#' 
+#' @title Broadcast a variable to all workers
+#'
 #' @description
 #' Broadcast a read-only variable to the cluster, returning a \code{Broadcast}
 #' object for reading it in distributed functions.
 #'
-#' @param sc Spark Context to use 
+#' @param sc Spark Context to use
 #' @param object Object to be broadcast
 #' @export
 #' @examples
@@ -139,7 +139,7 @@ includePackage <- function(sc, pkg) {
 #' # Large Matrix object that we want to broadcast
 #' randomMat <- matrix(nrow=100, ncol=10, data=rnorm(1000))
 #' randomMatBr <- broadcast(sc, randomMat)
-#' 
+#'
 #' # Use the broadcast variable inside the function
 #' useBroadcast <- function(x) {
 #'   sum(value(randomMatBr) * x)
@@ -156,4 +156,24 @@ broadcast <- function(sc, object) {
 
   id <- as.character(.jsimplify(.jcall(jBroadcast, "J", "id")))
   Broadcast(id, object, jBroadcast, objName)
+}
+
+#' @title Set the checkpoint directory
+#'
+#' Set the directory under which RDDs are going to be checkpointed. The
+#' directory must be a HDFS path if running on a cluster.
+#'
+#' @param sc Spark Context to use
+#' @param dirName Directory path
+#' @export
+#' @examples
+#'\dontrun{
+#' sc <- sparkR.init()
+#' setCheckpointDir(sc, "checkpoints")
+#' rdd <- parallelize(sc, 1:2, 2L)
+#' checkpoint(rdd)
+#'}
+setCheckpointDir <- function(sc, dirName) {
+  ssc <- .jcall(sc, "Lorg/apache/spark/SparkContext;", "sc")
+  .jcall(ssc, "V", "setCheckpointDir", dirName)
 }


### PR DESCRIPTION
Maintaining the two bookkeeping fields, `isCached` and `isCheckpointed`, fields is useful for implementing pipelining. The addition of the two methods accompanies because they are the only methods that modify these fields; however, we should complete the methods (properly implement checkpoint-related functionalities; add `persist()`; add tests) later, perhaps in another PR.
