### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# Based on https://github.com/craigcitro/r-travis
+
+language: java
+
+before_install:
+  - cd pkg
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - ./travis-tool.sh bootstrap
+install:
+  - sudo R CMD javareconf
+  - ./travis-tool.sh install_deps
+  - ./travis-tool.sh install_r_binary Matrix
+  - cd ..
+  - ./install-dev.sh
+script:
+  - ./run-tests.sh
+
+on_failure:
+  - ./travis-tool.sh dump_logs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # R on Spark
 
+[![Build Status](https://travis-ci.org/amplab-extras/SparkR-pkg.png?branch=master)](https://travis-ci.org/amplab-extras/SparkR-pkg)
+
 SparkR is an R package that provides a light-weight frontend to use Spark from
 R.
 


### PR DESCRIPTION
This commit adds a Travis CI configuration using the scripts in [craigcitro/r-travis](https://github.com/craigcitro/r-travis).

After merging this, visit https://travis-ci.org/profile to enable the GitHub integration hook.
