### PR TITLE
Search rLibDir in worker before libPaths

### DIFF
--- a/pkg/inst/worker/worker.R
+++ b/pkg/inst/worker/worker.R
@@ -18,7 +18,7 @@ outputCon <- file(outputFileName, open="wb")
 # TODO: Figure out if we can avoid this by not loading any objects that require
 # SparkR namespace
 rLibDir <- readLines(inputCon, n = 1)
-.libPaths(c(.libPaths(), rLibDir))
+.libPaths(c(rLibDir, .libPaths()))
 
 suppressPackageStartupMessages(library(SparkR))
 


### PR DESCRIPTION
This ensures we pick up the SparkR intended and not an older version
installed on the same machine
