### PR TITLE
Fixes for using SparkR with Hadoop2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ If you wish to try out the package directly from github, you can use `install_gi
     library(devtools)
     install_github("amplab-extras/SparkR-pkg", subdir="pkg")
 
+SparkR by default links to Hadoop 1.0.4. To use SparkR with other Hadoop
+versions, you will need to rebuild SparkR with the same version that [Spark is
+linked
+to](http://spark.incubator.apache.org/docs/latest/index.html#a-note-about-hadoop-versions). 
+For example to use SparkR with a CDH 4.2.0 MR1 cluster, you can run
+
+    SPARK_HADOOP_VERSION=2.0.0-mr1-cdh4.2.0 ./install-dev.sh
+
 ## Running sparkR
 If you have cloned and built SparkR, you can start using it by launching the SparkR
 shell with

--- a/pkg/src/build.sbt
+++ b/pkg/src/build.sbt
@@ -21,27 +21,34 @@ libraryDependencies ++= Seq(
 )
 
 {
+  val excludeCglib = ExclusionRule(organization = "org.sonatype.sisu.inject")
+  val excludeJackson = ExclusionRule(organization = "org.codehaus.jackson")
+  val excludeNetty = ExclusionRule(organization = "org.jboss.netty")
+  val excludeAsm = ExclusionRule(organization = "asm")
+  val excludeSnappy = ExclusionRule(organization = "org.xerial.snappy")
   val defaultHadoopVersion = "1.0.4"
   val hadoopVersion =
     scala.util.Properties.envOrElse("SPARK_HADOOP_VERSION", defaultHadoopVersion)
-  libraryDependencies += "org.apache.hadoop" % "hadoop-client" % hadoopVersion
+  libraryDependencies += "org.apache.hadoop" % "hadoop-client" % hadoopVersion excludeAll(excludeJackson, excludeNetty, excludeAsm, excludeCglib)
 }
 
 resolvers ++= Seq(
   "Typesafe" at "http://repo.typesafe.com/typesafe/releases",
   "Scala Tools Snapshots" at "http://scala-tools.org/repo-snapshots/",
+  "Cloudera Repository"  at "https://repository.cloudera.com/artifactory/cloudera-repos/",
   "Spray" at "http://repo.spray.cc"
 )
 
 mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
   {
-    case PathList("javax", "servlet", xs @ _*)           => MergeStrategy.first
-    case PathList(ps @ _*) if ps.last endsWith ".html"   => MergeStrategy.first
-    case "application.conf"                              => MergeStrategy.concat
-    case "reference.conf"                                => MergeStrategy.concat
-    case "log4j.properties"                              => MergeStrategy.first
-    case m if m.toLowerCase.endsWith("manifest.mf")      => MergeStrategy.discard
-    case m if m.toLowerCase.matches("meta-inf.*\\.sf$")  => MergeStrategy.discard
+    case PathList("javax", "servlet", xs @ _*)              => MergeStrategy.first
+    case PathList(ps @ _*) if ps.last endsWith ".html"      => MergeStrategy.first
+    case "application.conf"                                 => MergeStrategy.concat
+    case "reference.conf"                                   => MergeStrategy.concat
+    case "log4j.properties"                                 => MergeStrategy.first
+    case m if m.toLowerCase.endsWith("manifest.mf")         => MergeStrategy.discard
+    case m if m.toLowerCase.matches("meta-inf/services.*$") => MergeStrategy.concat
+    case m if m.toLowerCase.matches("meta-inf.*\\.sf$")     => MergeStrategy.discard
     case _ => MergeStrategy.first
   }
 }


### PR DESCRIPTION
1. Exclude ASM, Netty from Hadoop similar to Spark.
2. Concat services files to ensure HDFS filesystems work.
3. Update README with an example

Addresses #17
