### PR TITLE
Fix isRdd() to properly check for class

### DIFF
--- a/pkg/R/utils.R
+++ b/pkg/R/utils.R
@@ -65,7 +65,7 @@ deserializeByteArrays <- function(byteArrs) {
 # Returns TRUE if `name` refers to an RDD in the given environment `env`
 isRDD <- function(name, env) {
   obj <- get(name, envir=env)
-  class(obj) == "RDD"
+  inherits(obj, "RDD")
 }
 
 # Returns TRUE if `name` is a function in the SparkR package.


### PR DESCRIPTION
The old approach, class(obj) == "RDD" returns a vector as long
as class attribute of obj.  For example:
    > obj <- structure(list(), class = c("classA", "classB"))
    > class(obj) == "RDD"
    [1] FALSE FALSE
This causes getDependencies to fail.  Changed to:
inherits(obj, "RDD")
