### PR TITLE
Exclude protobuf from Spark dependency in Maven

### DIFF
--- a/pkg/src/pom.xml
+++ b/pkg/src/pom.xml
@@ -31,6 +31,12 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.10</artifactId>
       <version>0.9.0-incubating</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
This avoids pulling in multiple versions of protobuf from Spark (Mesos technically) and Hadoop. Excluding any protobuf dependencies from Spark and relying on Hadoop to pull in the required version seems to work in a local test.

Fixes #33

@pwendell , can you take a look and see if this is a reasonable workaround till Mesos shades protobuf ?
