### PR TITLE
Cache sbt dependencies in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ cache:
     - $HOME/.ivy2
     - $HOME/.sbt
 
-on_failure:
+after_failure:
   - ./travis-tool.sh dump_logs


### PR DESCRIPTION
This is an attempt to speedup the travis builds.
