### PR TITLE
Move up Hadoop in pom.xml and add back protobufs

### DIFF
--- a/pkg/src/pom.xml
+++ b/pkg/src/pom.xml
@@ -27,17 +27,8 @@
     </repository>
   </repositories>
   <dependencies>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
-      <version>0.9.0-incubating</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+    <!-- NOTE: Adding the hadoop dependency first ensures
+         that we pull in protobuf from Hadoop before Spark -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
@@ -60,6 +51,11 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.10</artifactId>
+      <version>0.9.0-incubating</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
As Hadoop 1.0.4 doesn't use protobufs, we can't exclude protobufs from Spark always. This change tries to order the dependencies so that the shading plugin first picks up Hadoop's protobufs over Mesos.

Note that this should all go away once Mesos shades their jars https://issues.apache.org/jira/browse/MESOS-1203

This should hopefully fix #41
