### PR TITLE
delay object loading to avoid namespace issues

### DIFF
--- a/pkg/inst/worker/worker.R
+++ b/pkg/inst/worker/worker.R
@@ -39,28 +39,24 @@ sink(stderr())
 # read function dependencies
 depsLen <- readInt(inputCon)
 if (depsLen > 0) {
-	execFunctionDeps <- readRawLen(inputCon, depsLen)
-}
-# Include packages as required
-packageNames <- unserialize(readRaw(inputCon))
-for (pkg in packageNames) {
-	suppressPackageStartupMessages(require(as.character(pkg), character.only=TRUE))
-}
-if (depsLen > 0) {
-	# load the dependencies into current environment
-	depsFileName <- tempfile(pattern="spark-exec", fileext=".deps")
-	depsFile <- file(depsFileName, open="wb")
-	writeBin(execFunctionDeps, depsFile, endian="big")
-	close(depsFile)
-	
-	load(depsFileName)
-	unlink(depsFileName)
+  execFunctionDeps <- readRawLen(inputCon, depsLen)
+
+  # load the dependencies into current environment
+  depsFileName <- tempfile(pattern="spark-exec", fileext=".deps")
+  depsFile <- file(depsFileName, open="wb")
+  writeBin(execFunctionDeps, depsFile, endian="big")
+  close(depsFile)
 }
 
 # Include packages as required
 packageNames <- unserialize(readRaw(inputCon))
 for (pkg in packageNames) {
   suppressPackageStartupMessages(require(as.character(pkg), character.only=TRUE))
+}
+
+if (depsLen > 0) {
+	load(depsFileName)
+	unlink(depsFileName)
 }
 
 # Read and set broadcast variables


### PR DESCRIPTION
By loading objects before packages have been loaded, if an object is a function that needs a private object in one of those packages, e.g. a private function, said object will be unavailable. You can see a warning that the package was not available and its namespace have been replaced by globalEnv. Reproducing the error is fairly complex, as I discovered it developing a package that depends on SparkR and has private functions that are called in the SparkR worker as part of the map function (plyrmr, spark branch). Let me know if you absolutely need to repro the error or can accept the patch based on the above argument.
