### PR TITLE
Use a better list append in shuffles

### DIFF
--- a/pkg/inst/worker/serialize.R
+++ b/pkg/inst/worker/serialize.R
@@ -69,13 +69,14 @@ writeEnvironment <- function(con, e, keyValPairsSerialized = TRUE) {
   }
 }
 
-# Add an item to an accumulator. The accumulator should have
-# three fields: size, counter and data
+# Fast append to list by using an accumulator.
+# http://stackoverflow.com/questions/17046336/here-we-go-again-append-an-element-to-a-list-in-r
 #
+# The accumulator should has three fields size, counter and data.
 # This function amortizes the allocation cost by doubling
 # the size of the list every time it fills up.
 addItemToAccumulator <- function(acc, item) {
-  if(acc$counter == acc$size ) {
+  if(acc$counter == acc$size) {
     acc$size <- acc$size * 2
     length(acc$data) <- acc$size
   }

--- a/pkg/inst/worker/worker.R
+++ b/pkg/inst/worker/worker.R
@@ -107,8 +107,6 @@ if (isEmpty != 0) {
         acc$data <- list(NULL)
         acc$size <- 1
       }
-      # Fast append to list from
-      # http://stackoverflow.com/questions/17046336/here-we-go-again-append-an-element-to-a-list-in-r
       addItemToAccumulator(acc, tuple)
       res[[bucket]] <- acc
     }


### PR DESCRIPTION
This is helpful in scenarios where we have a large number of values in a bucket. 

For example in the test case used in #57 (40000 lines with string keys and around 20k values per bucket), with the master branch it takes around 104 seconds on my laptop for partitionBy.

With this patch it takes around 8.57 seconds to do the same operation.

CC @zhangyouhua @piccolbo
