### PR TITLE
Delete temporary files after they are used

### DIFF
--- a/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
+++ b/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
@@ -77,7 +77,7 @@ private class PairwiseRRDD[T: ClassTag](
       }
       var _nextObj = read()
 
-      def hasNext = {
+      def hasNext(): Boolean = {
         val hasMore = !(_nextObj._1 == 0 && _nextObj._2.length == 0)
         if (!hasMore) {
           // Delete the temporary file we created as we are done reading it
@@ -155,7 +155,7 @@ class RRDD[T: ClassTag](
       }
       var _nextObj = read()
 
-      def hasNext = {
+      def hasNext(): Boolean = {
         val hasMore = _nextObj.length != 0
         if (!hasMore) {
           // Delete the temporary file we created as we are done reading it


### PR DESCRIPTION
This patch explicitly deletes temporary files after they have been read. This is required as using `deleteOnExit` does not seem to take effect when the JVM created by rJava exits.

cc @zhangyouhua
