### PR TITLE
Update readme for spark version 1.10 as merge commit 67d067a206e has upgraded to build against 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ R.
 ### Requirements
 SparkR requires Scala 2.10 and Spark version >= 0.9.0. Current build by default uses the 1.1.0
 candidate from the Apache staging repositories. You can also build SparkR against a
-different Spark version (>= 1.1.0) by modifying `pkg/src/build.sbt`.
+different Spark version (>= 0.9.0) by modifying `pkg/src/build.sbt`.
 
 SparkR also requires the R package `rJava` to be installed. To install `rJava`,
 you can run the following command in R:


### PR DESCRIPTION
reference
https://github.com/amplab-extras/SparkR-pkg/commit/67d067a206e6bd583b07470345d0813a8253bf5e
- upgrade readme mentioning of spark 0.9.0
- removal oftext saying spark 09.0 is prerelease
- added links to devetools etc 
