### PR TITLE
changed sbt version

### DIFF
--- a/pkg/src/project/build.properties
+++ b/pkg/src/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.6


### PR DESCRIPTION
I have changed the sbt version since the current version used gives the following error 

```
Launching sbt from sbt/sbt-launch-0.12.4.jar
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=350m; support was removed in 8.0
error: error while loading CharSequence, class file '/Library/Java/JavaVirtualMachines/jdk1.8.0_20.jdk/Contents/Home/jre/lib/rt.jar(java/lang/CharSequence.class)' is broken
(bad constant pool tag 18 at byte 10)
[0m[[31merror[0m] [0mType error in expression[0m
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? 
make: *** [target/scala-2.10/sparkr-assembly-0.1.jar] Error 1
ERROR: compilation failed for package 'SparkR'
* removing '/Library/Frameworks/R.framework/Versions/3.1/Resources/library/SparkR'
Error: Command failed (1)
```

Upgrading the sbt version resolved the issue.
