### PR TITLE
SparkR Quick-Start and IDE Setup

### DIFF
--- a/SparkR_IDE_Setup.sh
+++ b/SparkR_IDE_Setup.sh
@@ -9,7 +9,7 @@ fi
 
 sudo yum install rstudio-0.98.1091-x86_64.rpm
 
-sudo rstudio-0.98.1091-x86_64.rpm
+rm rstudio-0.98.1091-x86_64.rpm
 
 # Add SparkR directory to .libPaths() in order to import SparkR into an Rstudio session
 


### PR DESCRIPTION
Includes .md files for a SparkR quick-start tutorial as well as as a short guide to getting Rstudio set up and working with SparkR on the Cloudera VM.

In addition, this commit includes a shell script that handles the Rstudio set-up.
