### PR TITLE
[SPARKR-164] Temporary files used by SparkR accumulat as time goes on.

### DIFF
--- a/pkg/inst/worker/worker.R
+++ b/pkg/inst/worker/worker.R
@@ -139,6 +139,8 @@ if (isOutputSerialized) {
 }
 
 close(outputCon)
+close(inputCon)
+unlink(inFileName)
 
 # Restore stdout
 sink()


### PR DESCRIPTION
https://sparkr.atlassian.net/browse/SPARKR-164

Verified that no temp file was left after running the pi example.
