### PR TITLE
[SPARKR-183] Fix the issue that parallelize collect tests are slow.

### DIFF
--- a/pkg/R/sparkRBackend.R
+++ b/pkg/R/sparkRBackend.R
@@ -73,17 +73,18 @@ invokeJava <- function(isStatic, objId, methodName, ...) {
   writeArgs(rc, args)
 
   # Construct the whole request message to send it once,
-  # avoiding write-write-read pattern in case of Nagle's algorithm
+  # avoiding write-write-read pattern in case of Nagle's algorithm.
+  # Refer to http://en.wikipedia.org/wiki/Nagle%27s_algorithm for the details.
   bytesToSend <- rawConnectionValue(rc)
   close(rc)
   rc <- rawConnection(raw(0), "r+")
   writeInt(rc, length(bytesToSend))
   writeBin(bytesToSend, rc)
-  bytesToSend <- rawConnectionValue(rc)
+  requestMessage <- rawConnectionValue(rc)
   close(rc)
 
   conn <- get(".sparkRCon", .sparkREnv)
-  writeBin(bytesToSend, conn)
+  writeBin(requestMessage, conn)
 
   # TODO: check the status code to output error information
   returnStatus <- readInt(conn)


### PR DESCRIPTION
Construct the whole request message to send it once, avoiding write-write-read pattern in case of Nagle's algorithm.