### PR TITLE
Exclude hadoop client from Spark dependency

### DIFF
--- a/pkg/src/build.sbt
+++ b/pkg/src/build.sbt
@@ -26,6 +26,7 @@ libraryDependencies ++= Seq(
   val excludeNetty = ExclusionRule(organization = "org.jboss.netty")
   val excludeAsm = ExclusionRule(organization = "asm")
   val excludeSnappy = ExclusionRule(organization = "org.xerial.snappy")
+  val excludeHadoop = ExclusionRule(organization = "org.apache.hadoop")
   val sbtYarnFlag = scala.util.Properties.envOrElse("USE_YARN", "")
   val defaultHadoopVersion = "1.0.4"
   val defaultSparkVersion = "1.1.0"
@@ -33,7 +34,7 @@ libraryDependencies ++= Seq(
   val sparkVersion = scala.util.Properties.envOrElse("SPARK_VERSION", defaultSparkVersion)
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion excludeAll(excludeJackson, excludeNetty, excludeAsm, excludeCglib),
-    "org.apache.spark" % "spark-core_2.10" % sparkVersion
+    "org.apache.spark" % "spark-core_2.10" % sparkVersion excludeAll(excludeHadoop)
   ) ++ (if (sbtYarnFlag != "") {
           val defaultYarnVersion = "2.4.0"
           val yarnVersion = scala.util.Properties.envOrElse("SPARK_YARN_VERSION", defaultYarnVersion)

--- a/pkg/src/pom.xml
+++ b/pkg/src/pom.xml
@@ -101,6 +101,12 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.10</artifactId>
       <version>${spark.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This fixes builds using Spark 1.2 inheriting the wrong hadoop-client version (especially with SBT).

Before this fix if you ran `SPARK_VERSION=1.2.0 ./install-dev.sh` you would see `hadoop-client-2.2.0` being included even though our hadoop-client version is set to 1.0.4. This is because spark-core depends on Hadoop Client 2.2.0 http://mvnrepository.com/artifact/org.apache.spark/spark-core_2.10/1.2.0
