### PR TITLE
[SPARKR-200][SPARKR-149] Fix path, classpath separator for Windows

### DIFF
--- a/pkg/R/sparkR.R
+++ b/pkg/R/sparkR.R
@@ -90,10 +90,13 @@ sparkR.init <- function(
     normalizePath(c(as.character(.sparkREnv$assemblyJarPath), as.character(sparkJars))))
 
   # Classpath separator is ";" on Windows
+  # URI needs four /// as from http://stackoverflow.com/a/18522792
   if (.Platform$OS.type == "unix") {
     collapseChar <- ":"
+    uriSep <- "//"
   } else {
     collapseChar <- ";"
+    uriSep <- "////"
   }
   cp <- paste0(jars, collapse = collapseChar)
 
@@ -131,7 +134,7 @@ sparkR.init <- function(
   }
 
   nonEmptyJars <- Filter(function(x) { x != "" }, jars)
-  localJarPaths <- sapply(nonEmptyJars, function(j) { utils::URLencode(paste("file://", j, sep = "")) })
+  localJarPaths <- sapply(nonEmptyJars, function(j) { utils::URLencode(paste("file:", uriSep, j, sep = "")) })
 
   assign(
     ".sparkRjsc",

--- a/pkg/R/sparkR.R
+++ b/pkg/R/sparkR.R
@@ -131,12 +131,7 @@ sparkR.init <- function(
   }
 
   nonEmptyJars <- Filter(function(x) { x != "" }, jars)
-  # URIs don't work very well on Windows, so just use paths.
-  localJarPaths <- if (.Platform$OS.type == "unix") {
-    sapply(nonEmptyJars, function(j) { paste("file://", j, sep = "") })
-  } else {
-    nonEmptyJars
-  }
+  localJarPaths <- sapply(nonEmptyJars, function(j) { utils::URLencode(paste("file://", j, sep = "")) })
 
   assign(
     ".sparkRjsc",

--- a/pkg/R/sparkRClient.R
+++ b/pkg/R/sparkRClient.R
@@ -33,6 +33,8 @@ launchBackend <- function(
   } else {
     java_bin <- java_bin_name
   }
+  # Quote the classpath to make sure it handles spaces on Windows
+  classPath <- shQuote(classPath)
   combinedArgs <- paste(javaOpts, "-cp", classPath, mainClass, args, sep = " ")
   cat("Launching java with command ", java_bin, " ", combinedArgs, "\n")
   invisible(system2(java_bin, combinedArgs, wait = F))


### PR DESCRIPTION
This PR fixes a couple of problems reported by users on Windows

- The first fix is to make the classpath separator `;` as described in [1]
- The second fix is to handle spaces in the install path (in Windows, Unix-like platforms). The solution that seems to work across all platforms is to convert the jar paths to URIs and encode the URIs using `URLEncode`

Tested on Mac, Windows VM and Linux VM. P.S: Reviewers might find it useful to test using something like
```
library(devtools)
with_lib("/tmp/sparkr install", install_github(repo = "shivaram/SparkR-pkg/pkg@windows-space-fix"))
```

[1] http://stackoverflow.com/a/4528456/4577954