### PR TITLE
[SPARKR-208] Changed SQLContext.R#parquetFile signature to match the java version

### DIFF
--- a/pkg/R/SQLContext.R
+++ b/pkg/R/SQLContext.R
@@ -62,17 +62,15 @@ jsonRDD <- function(sqlCtx, rdd, schema = NULL, samplingRatio = 1.0) {
 #' Loads a Parquet file, returning the result as a DataFrame.
 #'
 #' @param sqlCtx SQLContext to use
-#' @param path Path of file to read. A vector of multiple paths is allowed.
+#' @param ... Path(s) of parquet file(s) to read.
 #' @return DataFrame
 #' @export
 
 # TODO: Implement saveasParquetFile and write examples for both
-parquetFile <- function(sqlCtx, path) {
+parquetFile <- function(sqlCtx, ...) {
   # Allow the user to have a more flexible definiton of the text file path
-  path <- normalizePath(path)
-  # Convert a string vector of paths to a string containing comma separated paths
-  path <- paste(path, collapse = ",")
-  sdf <- callJMethod(sqlCtx, "parquetFile", path)
+  paths <- lapply(list(...), normalizePath)
+  sdf <- callJMethod(sqlCtx, "parquetFile", paths)
   dataFrame(sdf)
 }
 

--- a/pkg/inst/tests/test_sparkSQL.R
+++ b/pkg/inst/tests/test_sparkSQL.R
@@ -527,15 +527,23 @@ test_that("withColumn() and withColumnRenamed()", {
   expect_true(columns(newDF2)[1] == "newerAge")
 })
 
-# TODO: Enable and test once the parquetFile PR has been merged
-# test_that("saveAsParquetFile() on DataFrame and works with parquetFile", {
-#   df <- jsonFile(sqlCtx, jsonPath)
-#   parquetPath <- tempfile(pattern="spark-test", fileext=".tmp")
-#   saveAsParquetFile(df, parquetPath)
-#   parquetDF <- parquetFile(sqlCtx, parquetPath)
-#   expect_true(inherits(parquetDF, "DataFrame"))
-#   expect_equal(collect(df), collect(parquetDF))
-#   unlink(parquetPath)
-# })
+test_that("saveDF() on DataFrame and works with parquetFile", {
+  df <- jsonFile(sqlCtx, jsonPath)
+  saveDF(df, parquetPath, "parquet", mode="overwrite")
+  parquetDF <- parquetFile(sqlCtx, parquetPath)
+  expect_true(inherits(parquetDF, "DataFrame"))
+  expect_equal(collect(df), collect(parquetDF))
+})
 
+test_that("parquetFile works with multiple input paths", {
+  df <- jsonFile(sqlCtx, jsonPath)
+  saveDF(df, parquetPath, "parquet", mode="overwrite")
+  parquetPath2 <- tempfile(pattern = "parquetPath2", fileext = ".parquet")
+  saveDF(df, parquetPath2, "parquet", mode="overwrite")
+  parquetDF <- parquetFile(sqlCtx, parquetPath, parquetPath2)
+  expect_true(inherits(parquetDF, "DataFrame"))
+  expect_true(count(parquetDF) == count(df)*2)
+})
+
+unlink(parquetPath)
 unlink(jsonPath)


### PR DESCRIPTION
This is a simple fix to make parquetFile work in R. See https://sparkr.atlassian.net/browse/SPARKR-208 for details.