### PR TITLE
Update method signatures to use generic arg

### DIFF
--- a/pkg/R/RDD.R
+++ b/pkg/R/RDD.R
@@ -265,7 +265,7 @@ setGeneric("unpersist", function(x) { standardGeneric("unpersist") })
 setMethod("unpersist",
           signature(x = "RDD"),
           function(x) {
-            callJMethod(getJRDD(x, "unpersist"))
+            callJMethod(getJRDD(x), "unpersist")
             x@env$isCached <- FALSE
             x
           })
@@ -399,7 +399,7 @@ setGeneric("collectAsMap", function(x) { standardGeneric("collectAsMap") })
 setMethod("collectAsMap",
           signature(x = "RDD"),
           function(x) {
-            pairList <- collect(rdd)
+            pairList <- collect(x)
             map <- new.env()
             lapply(pairList, function(i) { assign(as.character(i[[1]]), i[[2]], envir = map) })
             as.list(map)

--- a/pkg/R/RDD.R
+++ b/pkg/R/RDD.R
@@ -97,18 +97,18 @@ PipelinedRDD <- function(prev, func) {
 
 
 # The jrdd accessor function.
-setGeneric("getJRDD", function(x, ...) { standardGeneric("getJRDD") })
-setMethod("getJRDD", signature(x = "RDD"), function(x) x@jrdd )
-setMethod("getJRDD", signature(x = "PipelinedRDD"),
-          function(x, dataSerialization = TRUE) {
-            if (!is.null(x@env$jrdd_val)) {
-              return(x@env$jrdd_val)
+setGeneric("getJRDD", function(rdd, ...) { standardGeneric("getJRDD") })
+setMethod("getJRDD", signature(rdd = "RDD"), function(rdd) rdd@jrdd )
+setMethod("getJRDD", signature(rdd = "PipelinedRDD"),
+          function(rdd, dataSerialization = TRUE) {
+            if (!is.null(rdd@env$jrdd_val)) {
+              return(rdd@env$jrdd_val)
             }
 
             # TODO: This is to handle anonymous functions. Find out a
             # better way to do this.
             computeFunc <- function(split, part) {
-              x@func(split, part)
+              rdd@func(split, part)
             }
             serializedFuncArr <- serialize("computeFunc", connection = NULL)
 
@@ -120,13 +120,13 @@ setMethod("getJRDD", signature(x = "PipelinedRDD"),
 
             depsBin <- getDependencies(computeFunc)
 
-            prev_jrdd <- x@prev_jrdd
+            prev_jrdd <- rdd@prev_jrdd
 
             if (dataSerialization) {
               rddRef <- newJObject("edu.berkeley.cs.amplab.sparkr.RRDD",
                                    callJMethod(prev_jrdd, "rdd"),
                                    serializedFuncArr,
-                                   x@env$prev_serialized,
+                                   rdd@env$prev_serialized,
                                    depsBin,
                                    packageNamesArr,
                                    as.character(.sparkREnv[["libname"]]),
@@ -136,7 +136,7 @@ setMethod("getJRDD", signature(x = "PipelinedRDD"),
               rddRef <- newJObject("edu.berkeley.cs.amplab.sparkr.StringRRDD",
                                    callJMethod(prev_jrdd, "rdd"),
                                    serializedFuncArr,
-                                   x@env$prev_serialized,
+                                   rdd@env$prev_serialized,
                                    depsBin,
                                    packageNamesArr,
                                    as.character(.sparkREnv[["libname"]]),
@@ -144,9 +144,9 @@ setMethod("getJRDD", signature(x = "PipelinedRDD"),
                                    callJMethod(prev_jrdd, "classTag"))
             }
             # Save the serialization flag after we create a RRDD
-            x@env$serialized <- dataSerialization
-            x@env$jrdd_val <- callJMethod(rddRef, "asJavaRDD") # rddRef$asJavaRDD()
-            x@env$jrdd_val
+            rdd@env$serialized <- dataSerialization
+            rdd@env$jrdd_val <- callJMethod(rddRef, "asJavaRDD") # rddRef$asJavaRDD()
+            rdd@env$jrdd_val
           })
 
 

--- a/pkg/R/RDD.R
+++ b/pkg/R/RDD.R
@@ -97,18 +97,18 @@ PipelinedRDD <- function(prev, func) {
 
 
 # The jrdd accessor function.
-setGeneric("getJRDD", function(rdd, ...) { standardGeneric("getJRDD") })
-setMethod("getJRDD", signature(rdd = "RDD"), function(rdd) rdd@jrdd )
-setMethod("getJRDD", signature(rdd = "PipelinedRDD"),
-          function(rdd, dataSerialization = TRUE) {
-            if (!is.null(rdd@env$jrdd_val)) {
-              return(rdd@env$jrdd_val)
+setGeneric("getJRDD", function(x, ...) { standardGeneric("getJRDD") })
+setMethod("getJRDD", signature(x = "RDD"), function(x) x@jrdd )
+setMethod("getJRDD", signature(x = "PipelinedRDD"),
+          function(x, dataSerialization = TRUE) {
+            if (!is.null(x@env$jrdd_val)) {
+              return(x@env$jrdd_val)
             }
 
             # TODO: This is to handle anonymous functions. Find out a
             # better way to do this.
             computeFunc <- function(split, part) {
-              rdd@func(split, part)
+              x@func(split, part)
             }
             serializedFuncArr <- serialize("computeFunc", connection = NULL)
 
@@ -120,13 +120,13 @@ setMethod("getJRDD", signature(rdd = "PipelinedRDD"),
 
             depsBin <- getDependencies(computeFunc)
 
-            prev_jrdd <- rdd@prev_jrdd
+            prev_jrdd <- x@prev_jrdd
 
             if (dataSerialization) {
               rddRef <- newJObject("edu.berkeley.cs.amplab.sparkr.RRDD",
                                    callJMethod(prev_jrdd, "rdd"),
                                    serializedFuncArr,
-                                   rdd@env$prev_serialized,
+                                   x@env$prev_serialized,
                                    depsBin,
                                    packageNamesArr,
                                    as.character(.sparkREnv[["libname"]]),
@@ -136,7 +136,7 @@ setMethod("getJRDD", signature(rdd = "PipelinedRDD"),
               rddRef <- newJObject("edu.berkeley.cs.amplab.sparkr.StringRRDD",
                                    callJMethod(prev_jrdd, "rdd"),
                                    serializedFuncArr,
-                                   rdd@env$prev_serialized,
+                                   x@env$prev_serialized,
                                    depsBin,
                                    packageNamesArr,
                                    as.character(.sparkREnv[["libname"]]),
@@ -144,9 +144,9 @@ setMethod("getJRDD", signature(rdd = "PipelinedRDD"),
                                    callJMethod(prev_jrdd, "classTag"))
             }
             # Save the serialization flag after we create a RRDD
-            rdd@env$serialized <- dataSerialization
-            rdd@env$jrdd_val <- callJMethod(rddRef, "asJavaRDD") # rddRef$asJavaRDD()
-            rdd@env$jrdd_val
+            x@env$serialized <- dataSerialization
+            x@env$jrdd_val <- callJMethod(rddRef, "asJavaRDD") # rddRef$asJavaRDD()
+            x@env$jrdd_val
           })
 
 
@@ -170,7 +170,7 @@ setValidity("RDD",
 #'
 #' Persist this RDD with the default storage level (MEMORY_ONLY).
 #'
-#' @param rdd The RDD to cache
+#' @param x The RDD to cache
 #' @rdname cache-methods
 #' @export
 #' @examples
@@ -179,16 +179,16 @@ setValidity("RDD",
 #' rdd <- parallelize(sc, 1:10, 2L)
 #' cache(rdd)
 #'}
-setGeneric("cache", function(rdd) { standardGeneric("cache") })
+setGeneric("cache", function(x) { standardGeneric("cache") })
 
 #' @rdname cache-methods
 #' @aliases cache,RDD-method
 setMethod("cache",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            callJMethod(getJRDD(rdd), "cache")
-            rdd@env$isCached <- TRUE
-            rdd
+          signature(x = "RDD"),
+          function(x) {
+            callJMethod(getJRDD(x), "cache")
+            x@env$isCached <- TRUE
+            x
           })
 
 #' Persist an RDD
@@ -197,7 +197,7 @@ setMethod("cache",
 #' supported storage levels, refer to
 #' http://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence.
 #'
-#' @param rdd The RDD to persist
+#' @param x The RDD to persist
 #' @param newLevel The new storage level to be assigned
 #' @rdname persist
 #' @export
@@ -207,13 +207,13 @@ setMethod("cache",
 #' rdd <- parallelize(sc, 1:10, 2L)
 #' persist(rdd, "MEMORY_AND_DISK")
 #'}
-setGeneric("persist", function(rdd, newLevel) { standardGeneric("persist") })
+setGeneric("persist", function(x, newLevel) { standardGeneric("persist") })
 
 #' @rdname persist
 #' @aliases persist,RDD-method
 setMethod("persist",
-          signature(rdd = "RDD", newLevel = "character"),
-          function(rdd, newLevel = c("DISK_ONLY",
+          signature(x = "RDD", newLevel = "character"),
+          function(x, newLevel = c("DISK_ONLY",
                                      "DISK_ONLY_2",
                                      "MEMORY_AND_DISK",
                                      "MEMORY_AND_DISK_2",
@@ -238,9 +238,9 @@ setMethod("persist",
               "MEMORY_ONLY_SER_2" = callJStatic("org.apache.spark.storage.StorageLevel", "MEMORY_ONLY_SER_2"),
               "OFF_HEAP" = callJStatic("org.apache.spark.storage.StorageLevel", "OFF_HEAP"))
             
-            callJMethod(getJRDD(rdd), "persist", storageLevel)
-            rdd@env$isCached <- TRUE
-            rdd
+            callJMethod(getJRDD(x), "persist", storageLevel)
+            x@env$isCached <- TRUE
+            x
           })
 
 #' Unpersist an RDD
@@ -258,16 +258,16 @@ setMethod("persist",
 #' cache(rdd) # rdd@@env$isCached == TRUE
 #' unpersist(rdd) # rdd@@env$isCached == FALSE
 #'}
-setGeneric("unpersist", function(rdd) { standardGeneric("unpersist") })
+setGeneric("unpersist", function(x) { standardGeneric("unpersist") })
 
 #' @rdname unpersist-methods
 #' @aliases unpersist,RDD-method
 setMethod("unpersist",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            callJMethod(getJRDD(rdd), "unpersist")
-            rdd@env$isCached <- FALSE
-            rdd
+          signature(x = "RDD"),
+          function(x) {
+            callJMethod(getJRDD(x, "unpersist"))
+            x@env$isCached <- FALSE
+            x
           })
 
 
@@ -289,22 +289,22 @@ setMethod("unpersist",
 #' rdd <- parallelize(sc, 1:10, 2L)
 #' checkpoint(rdd)
 #'}
-setGeneric("checkpoint", function(rdd) { standardGeneric("checkpoint") })
+setGeneric("checkpoint", function(x) { standardGeneric("checkpoint") })
 
 #' @rdname checkpoint-methods
 #' @aliases checkpoint,RDD-method
 setMethod("checkpoint",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            jrdd <- getJRDD(rdd)
+          signature(x = "RDD"),
+          function(x) {
+            jrdd <- getJRDD(x)
             callJMethod(jrdd, "checkpoint")
-            rdd@env$isCheckpointed <- TRUE
-            rdd
+            x@env$isCheckpointed <- TRUE
+            x
           })
 
 #' Gets the number of partitions of an RDD
 #'
-#' @param rdd A RDD.
+#' @param x A RDD.
 #' @return the number of partitions of rdd as an integer.
 #' @rdname numPartitions
 #' @export
@@ -314,14 +314,14 @@ setMethod("checkpoint",
 #' rdd <- parallelize(sc, 1:10, 2L)
 #' numPartitions(rdd)  # 2L
 #'}
-setGeneric("numPartitions", function(rdd) { standardGeneric("numPartitions") })
+setGeneric("numPartitions", function(x) { standardGeneric("numPartitions") })
 
 #' @rdname numPartitions
 #' @aliases numPartitions,RDD-method
 setMethod("numPartitions",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            jrdd <- getJRDD(rdd)
+          signature(x = "RDD"),
+          function(x) {
+            jrdd <- getJRDD(x)
             partitions <- callJMethod(jrdd, "splits")
             callJMethod(partitions, "size")
           })
@@ -331,7 +331,7 @@ setMethod("numPartitions",
 #' @description
 #' \code{collect} returns a list that contains all of the elements in this RDD.
 #'
-#' @param rdd The RDD to collect
+#' @param x The RDD to collect
 #' @param ... Other optional arguments to collect
 #' @param flatten FALSE if the list should not flattened
 #' @return a list containing elements in the RDD
@@ -344,15 +344,15 @@ setMethod("numPartitions",
 #' collect(rdd) # list from 1 to 10
 #' collectPartition(rdd, 0L) # list from 1 to 5
 #'}
-setGeneric("collect", function(rdd, ...) { standardGeneric("collect") })
+setGeneric("collect", function(x, ...) { standardGeneric("collect") })
 
 #' @rdname collect-methods
 #' @aliases collect,RDD-method
 setMethod("collect",
-          signature(rdd = "RDD"),
-          function(rdd, flatten = TRUE) {
+          signature(x = "RDD"),
+          function(x, flatten = TRUE) {
             # Assumes a pairwise RDD is backed by a JavaPairRDD.
-            collected <- callJMethod(getJRDD(rdd), "collect")
+            collected <- callJMethod(getJRDD(x), "collect")
             convertJListToRList(collected, flatten)
           })
 
@@ -364,16 +364,16 @@ setMethod("collect",
 #' in the specified partition of the RDD.
 #' @param partitionId the partition to collect (starts from 0)
 setGeneric("collectPartition",
-           function(rdd, partitionId) {
+           function(x, partitionId) {
              standardGeneric("collectPartition")
            })
 
 #' @rdname collect-methods
 #' @aliases collectPartition,integer,RDD-method
 setMethod("collectPartition",
-          signature(rdd = "RDD", partitionId = "integer"),
-          function(rdd, partitionId) {
-            jPartitionsList <- callJMethod(getJRDD(rdd),
+          signature(x = "RDD", partitionId = "integer"),
+          function(x, partitionId) {
+            jPartitionsList <- callJMethod(getJRDD(x),
                                            "collectPartitions",
                                            as.list(as.integer(partitionId)))
 
@@ -392,16 +392,16 @@ setMethod("collectPartition",
 #' rdd <- parallelize(sc, list(list(1, 2), list(3, 4)), 2L)
 #' collectAsMap(rdd) # list(`1` = 2, `3` = 4)
 #'}
-setGeneric("collectAsMap", function(rdd) { standardGeneric("collectAsMap") })
+setGeneric("collectAsMap", function(x) { standardGeneric("collectAsMap") })
 
 #' @rdname collect-methods
 #' @aliases collectAsMap,RDD-method
 setMethod("collectAsMap",
-          signature(rdd = "RDD"),
-          function(rdd) {
+          signature(x = "RDD"),
+          function(x) {
             pairList <- collect(rdd)
             map <- new.env()
-            lapply(pairList, function(x) { assign(as.character(x[[1]]), x[[2]], envir = map) })
+            lapply(pairList, function(i) { assign(as.character(i[[1]]), i[[2]], envir = map) })
             as.list(map)
           })
 
@@ -447,7 +447,7 @@ setMethod("length",
 #'
 #' Same as countByValue in Spark.
 #'
-#' @param rdd The RDD to count
+#' @param x The RDD to count
 #' @return list of (value, count) pairs, where count is number of each unique
 #' value in rdd.
 #' @rdname countByValue
@@ -458,15 +458,15 @@ setMethod("length",
 #' rdd <- parallelize(sc, c(1,2,3,2,1))
 #' countByValue(rdd) # (1,2L), (2,2L), (3,1L)
 #'}
-setGeneric("countByValue", function(rdd) { standardGeneric("countByValue") })
+setGeneric("countByValue", function(x) { standardGeneric("countByValue") })
 
 #' @rdname countByValue
 #' @aliases countByValue,RDD-method
 setMethod("countByValue",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            ones <- lapply(rdd, function(item) { list(item, 1L) })
-            collect(reduceByKey(ones, `+`, numPartitions(rdd)))
+          signature(x = "RDD"),
+          function(x) {
+            ones <- lapply(x, function(item) { list(item, 1L) })
+            collect(reduceByKey(ones, `+`, numPartitions(x)))
           })
 
 #' Apply a function to all elements
@@ -683,26 +683,26 @@ setMethod("Filter",
 #' rdd <- parallelize(sc, 1:10)
 #' reduce(rdd, "+") # 55
 #'}
-setGeneric("reduce", function(rdd, func) { standardGeneric("reduce") })
+setGeneric("reduce", function(x, func) { standardGeneric("reduce") })
 
 #' @rdname reduce
 #' @aliases reduce,RDD,ANY-method
 setMethod("reduce",
-          signature(rdd = "RDD", func = "ANY"),
-          function(rdd, func) {
+          signature(x = "RDD", func = "ANY"),
+          function(x, func) {
 
             reducePartition <- function(part) {
               Reduce(func, part)
             }
 
-            partitionList <- collect(lapplyPartition(rdd, reducePartition),
+            partitionList <- collect(lapplyPartition(x, reducePartition),
                                      flatten = FALSE)
             Reduce(func, partitionList)
           })
 
 #' Get the maximum element of an RDD.
 #'
-#' @param rdd The RDD to get the maximum element from
+#' @param x The RDD to get the maximum element from
 #' @export
 #' @rdname maximum
 #' @examples
@@ -711,19 +711,19 @@ setMethod("reduce",
 #' rdd <- parallelize(sc, 1:10)
 #' maximum(rdd) # 10
 #'}
-setGeneric("maximum", function(rdd) { standardGeneric("maximum") })
+setGeneric("maximum", function(x) { standardGeneric("maximum") })
 
 #' @rdname maximum
 #' @aliases maximum,RDD
 setMethod("maximum",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            reduce(rdd, max)
+          signature(x = "RDD"),
+          function(x) {
+            reduce(x, max)
           })
 
 #' Get the minimum element of an RDD.
 #'
-#' @param rdd The RDD to get the minimum element from
+#' @param x The RDD to get the minimum element from
 #' @export
 #' @rdname minimum
 #' @examples
@@ -732,19 +732,19 @@ setMethod("maximum",
 #' rdd <- parallelize(sc, 1:10)
 #' minimum(rdd) # 1
 #'}
-setGeneric("minimum", function(rdd) { standardGeneric("minimum") })
+setGeneric("minimum", function(x) { standardGeneric("minimum") })
 
 #' @rdname minimum
 #' @aliases minimum,RDD
 setMethod("minimum",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            reduce(rdd, min)
+          signature(x = "RDD"),
+          function(x) {
+            reduce(x, min)
           })
 
 #' Applies a function to all elements in an RDD, and force evaluation.
 #'
-#' @param rdd The RDD to apply the function
+#' @param x The RDD to apply the function
 #' @param func The function to be applied.
 #' @return invisible NULL.
 #' @export
@@ -755,18 +755,18 @@ setMethod("minimum",
 #' rdd <- parallelize(sc, 1:10)
 #' foreach(rdd, function(x) { save(x, file=...) })
 #'}
-setGeneric("foreach", function(rdd, func) { standardGeneric("foreach") })
+setGeneric("foreach", function(x, func) { standardGeneric("foreach") })
 
 #' @rdname foreach
 #' @aliases foreach,RDD,function-method
 setMethod("foreach",
-          signature(rdd = "RDD", func = "function"),
-          function(rdd, func) {
+          signature(x = "RDD", func = "function"),
+          function(x, func) {
             partition.func <- function(x) {
               lapply(x, func)
               NULL
             }
-            invisible(collect(mapPartitions(rdd, partition.func)))
+            invisible(collect(mapPartitions(x, partition.func)))
           })
 
 #' Applies a function to each partition in an RDD, and force evaluation.
@@ -780,14 +780,14 @@ setMethod("foreach",
 #' foreachPartition(rdd, function(part) { save(part, file=...); NULL })
 #'}
 setGeneric("foreachPartition", 
-           function(rdd, func) { standardGeneric("foreachPartition") })
+           function(x, func) { standardGeneric("foreachPartition") })
 
 #' @rdname foreach
 #' @aliases foreachPartition,RDD,function-method
 setMethod("foreachPartition",
-          signature(rdd = "RDD", func = "function"),
-          function(rdd, func) {
-            invisible(collect(mapPartitions(rdd, func)))
+          signature(x = "RDD", func = "function"),
+          function(x, func) {
+            invisible(collect(mapPartitions(x, func)))
           })
 
 #' Take elements from an RDD.
@@ -795,7 +795,7 @@ setMethod("foreachPartition",
 #' This function takes the first NUM elements in the RDD and
 #' returns them in a list.
 #'
-#' @param rdd The RDD to take elements from
+#' @param x The RDD to take elements from
 #' @param num Number of elements to take
 #' @rdname take
 #' @export
@@ -805,17 +805,17 @@ setMethod("foreachPartition",
 #' rdd <- parallelize(sc, 1:10)
 #' take(rdd, 2L) # list(1, 2)
 #'}
-setGeneric("take", function(rdd, num) { standardGeneric("take") })
+setGeneric("take", function(x, num) { standardGeneric("take") })
 
 #' @rdname take
 #' @aliases take,RDD,numeric-method
 setMethod("take",
-          signature(rdd = "RDD", num = "numeric"),
-          function(rdd, num) {
+          signature(x = "RDD", num = "numeric"),
+          function(x, num) {
             resList <- list()
             index <- -1
-            jrdd <- getJRDD(rdd)
-            numPartitions <- numPartitions(rdd)
+            jrdd <- getJRDD(x)
+            numPartitions <- numPartitions(x)
 
             # TODO(shivaram): Collect more than one partition based on size
             # estimates similar to the scala version of `take`.
@@ -834,7 +834,7 @@ setMethod("take",
               elems <- convertJListToRList(partition,
                                            flatten = TRUE,
                                            logicalUpperBound = size,
-                                           serialized = rdd@env$serialized)
+                                           serialized = x@env$serialized)
               # TODO: Check if this append is O(n^2)?
               resList <- append(resList, elems)
             }
@@ -846,7 +846,7 @@ setMethod("take",
 #' This function returns a new RDD containing the distinct elements in the
 #' given RDD. The same as `distinct()' in Spark.
 #'
-#' @param rdd The RDD to remove duplicates from.
+#' @param x The RDD to remove duplicates from.
 #' @param numPartitions Number of partitions to create.
 #' @rdname distinct
 #' @export
@@ -857,18 +857,18 @@ setMethod("take",
 #' sort(unlist(collect(distinct(rdd)))) # c(1, 2, 3)
 #'}
 setGeneric("distinct",
-           function(rdd, numPartitions) { standardGeneric("distinct") })
+           function(x, numPartitions) { standardGeneric("distinct") })
 
 setClassUnion("missingOrInteger", c("missing", "integer"))
 #' @rdname distinct
 #' @aliases distinct,RDD,missingOrInteger-method
 setMethod("distinct",
-          signature(rdd = "RDD", numPartitions = "missingOrInteger"),
-          function(rdd, numPartitions) {
+          signature(x = "RDD", numPartitions = "missingOrInteger"),
+          function(x, numPartitions) {
             if (missing(numPartitions)) {
-              numPartitions <- SparkR::numPartitions(rdd)
+              numPartitions <- SparkR::numPartitions(x)
             }
-            identical.mapped <- lapply(rdd, function(x) { list(x, NULL) })
+            identical.mapped <- lapply(x, function(x) { list(x, NULL) })
             reduced <- reduceByKey(identical.mapped,
                                    function(x, y) { x },
                                    numPartitions)
@@ -881,7 +881,7 @@ setMethod("distinct",
 #' The same as `sample()' in Spark. (We rename it due to signature
 #' inconsistencies with the `sample()' function in R's base package.)
 #'
-#' @param rdd The RDD to sample elements from
+#' @param x The RDD to sample elements from
 #' @param withReplacement Sampling with replacement or not
 #' @param fraction The (rough) sample target fraction
 #' @param seed Randomness seed value
@@ -895,16 +895,16 @@ setMethod("distinct",
 #' collect(sampleRDD(rdd, TRUE, 0.5, 9L)) # ~5 elements possibly with duplicates
 #'}
 setGeneric("sampleRDD",
-           function(rdd, withReplacement, fraction, seed) {
+           function(x, withReplacement, fraction, seed) {
              standardGeneric("sampleRDD")
            })
 
 #' @rdname sampleRDD
 #' @aliases sampleRDD,RDD
 setMethod("sampleRDD",
-          signature(rdd = "RDD", withReplacement = "logical",
+          signature(x = "RDD", withReplacement = "logical",
                     fraction = "numeric", seed = "integer"),
-          function(rdd, withReplacement, fraction, seed) {
+          function(x, withReplacement, fraction, seed) {
 
             # The sampler: takes a partition and returns its sampled version.
             samplingFunc <- function(split, part) {
@@ -941,13 +941,13 @@ setMethod("sampleRDD",
                 list()
             }
 
-            lapplyPartitionsWithIndex(rdd, samplingFunc)
+            lapplyPartitionsWithIndex(x, samplingFunc)
           })
 
 
 #' Return a list of the elements that are a sampled subset of the given RDD.
 #'
-#' @param rdd The RDD to sample elements from
+#' @param x The RDD to sample elements from
 #' @param withReplacement Sampling with replacement or not
 #' @param num Number of elements to return
 #' @param seed Randomness seed value
@@ -963,19 +963,19 @@ setMethod("sampleRDD",
 #' takeSample(rdd, FALSE, 5L, 16181618L)
 #'}
 setGeneric("takeSample",
-           function(rdd, withReplacement, num, seed) {
+           function(x, withReplacement, num, seed) {
              standardGeneric("takeSample")
            })
 #' @rdname takeSample
 #' @aliases takeSample,RDD
-setMethod("takeSample", signature(rdd = "RDD", withReplacement = "logical",
+setMethod("takeSample", signature(x = "RDD", withReplacement = "logical",
                                   num = "integer", seed = "integer"),
-          function(rdd, withReplacement, num, seed) {
+          function(x, withReplacement, num, seed) {
             # This function is ported from RDD.scala.
             fraction <- 0.0
             total <- 0
             multiplier <- 3.0
-            initialCount <- count(rdd)
+            initialCount <- count(x)
             maxSelected <- 0
             MAXINT <- .Machine$integer.max
 
@@ -997,7 +997,7 @@ setMethod("takeSample", signature(rdd = "RDD", withReplacement = "logical",
             }
 
             set.seed(seed)
-            samples <- collect(sampleRDD(rdd, withReplacement, fraction,
+            samples <- collect(sampleRDD(x, withReplacement, fraction,
                                          as.integer(ceiling(runif(1,
                                                                   -MAXINT,
                                                                   MAXINT)))))
@@ -1005,7 +1005,7 @@ setMethod("takeSample", signature(rdd = "RDD", withReplacement = "logical",
             # take samples; this shouldn't happen often because we use a big
             # multiplier for thei initial size
             while (length(samples) < total)
-              samples <- collect(sampleRDD(rdd, withReplacement, fraction,
+              samples <- collect(sampleRDD(x, withReplacement, fraction,
                                            as.integer(ceiling(runif(1,
                                                                     -MAXINT,
                                                                     MAXINT)))))
@@ -1016,7 +1016,7 @@ setMethod("takeSample", signature(rdd = "RDD", withReplacement = "logical",
 
 #' Creates tuples of the elements in this RDD by applying a function.
 #'
-#' @param rdd The RDD.
+#' @param x The RDD.
 #' @param func The function to be applied.
 #' @rdname keyBy
 #' @export
@@ -1026,22 +1026,22 @@ setMethod("takeSample", signature(rdd = "RDD", withReplacement = "logical",
 #' rdd <- parallelize(sc, list(1, 2, 3))
 #' collect(keyBy(rdd, function(x) { x*x })) # list(list(1, 1), list(4, 2), list(9, 3))
 #'}
-setGeneric("keyBy", function(rdd, func) { standardGeneric("keyBy") })
+setGeneric("keyBy", function(x, func) { standardGeneric("keyBy") })
 
 #' @rdname keyBy
 #' @aliases keyBy,RDD
 setMethod("keyBy",
-          signature(rdd = "RDD", func = "function"),
-          function(rdd, func) {
+          signature(x = "RDD", func = "function"),
+          function(x, func) {
             apply.func <- function(x) {
               list(func(x), x)
             }
-            lapply(rdd, apply.func)
+            lapply(x, apply.func)
           })
 
 #' Save this RDD as a SequenceFile of serialized objects.
 #'
-#' @param rdd The RDD to save
+#' @param x The RDD to save
 #' @param path The directory where the file is saved
 #' @rdname saveAsObjectFile
 #' @seealso objectFile
@@ -1052,25 +1052,25 @@ setMethod("keyBy",
 #' rdd <- parallelize(sc, 1:3)
 #' saveAsObjectFile(rdd, "/tmp/sparkR-tmp")
 #'}
-setGeneric("saveAsObjectFile", function(rdd, path) { standardGeneric("saveAsObjectFile") })
+setGeneric("saveAsObjectFile", function(x, path) { standardGeneric("saveAsObjectFile") })
 
 #' @rdname saveAsObjectFile
 #' @aliases saveAsObjectFile,RDD
 setMethod("saveAsObjectFile",
-          signature(rdd = "RDD", path = "character"),
-          function(rdd, path) {
+          signature(x = "RDD", path = "character"),
+          function(x, path) {
             # If the RDD is in string format, need to serialize it before saving it because when
             # objectFile() is invoked to load the saved file, only serialized format is assumed.
-            if (!rdd@env$serialized) {
-              rdd <- reserialize(rdd)
+            if (!x@env$serialized) {
+              x <- reserialize(x)
             }
             # Return nothing
-            invisible(callJMethod(getJRDD(rdd), "saveAsObjectFile", path))
+            invisible(callJMethod(getJRDD(x), "saveAsObjectFile", path))
           })
 
 #' Save this RDD as a text file, using string representations of elements.
 #'
-#' @param rdd The RDD to save
+#' @param x The RDD to save
 #' @param path The directory where the splits of the text file are saved
 #' @rdname saveAsTextFile
 #' @export
@@ -1080,17 +1080,17 @@ setMethod("saveAsObjectFile",
 #' rdd <- parallelize(sc, 1:3)
 #' saveAsTextFile(rdd, "/tmp/sparkR-tmp")
 #'}
-setGeneric("saveAsTextFile", function(rdd, path) { standardGeneric("saveAsTextFile") })
+setGeneric("saveAsTextFile", function(x, path) { standardGeneric("saveAsTextFile") })
 
 #' @rdname saveAsTextFile
 #' @aliases saveAsTextFile,RDD
 setMethod("saveAsTextFile",
-          signature(rdd = "RDD", path = "character"),
-          function(rdd, path) {
-            func <- function(x) {
-              toString(x)
+          signature(x = "RDD", path = "character"),
+          function(x, path) {
+            func <- function(str) {
+              toString(str)
             }
-            stringRdd <- lapply(rdd, func)
+            stringRdd <- lapply(x, func)
             # Return nothing
             invisible(
               callJMethod(getJRDD(stringRdd, dataSerialization = FALSE), "saveAsTextFile", path))
@@ -1098,7 +1098,7 @@ setMethod("saveAsTextFile",
 
 #' Sort an RDD by the given key function.
 #'
-#' @param rdd An RDD to be sorted.
+#' @param x An RDD to be sorted.
 #' @param func A function used to compute the sort key for each element.
 #' @param ascending A flag to indicate whether the sorting is ascending or descending.
 #' @param numPartitions Number of partitions to create.
@@ -1111,7 +1111,7 @@ setMethod("saveAsTextFile",
 #' rdd <- parallelize(sc, list(3, 2, 1))
 #' collect(sortBy(rdd, function(x) { x })) # list (1, 2, 3)
 #'}
-setGeneric("sortBy", function(rdd,
+setGeneric("sortBy", function(x,
                               func,
                               ascending = TRUE,
                               numPartitions = 1L) {
@@ -1121,20 +1121,20 @@ setGeneric("sortBy", function(rdd,
 #' @rdname sortBy
 #' @aliases sortBy,RDD,RDD-method
 setMethod("sortBy",
-          signature(rdd = "RDD", func = "function"),
-          function(rdd, func, ascending = TRUE, numPartitions = SparkR::numPartitions(rdd)) {          
-            values(sortByKey(keyBy(rdd, func), ascending, numPartitions))
+          signature(x = "RDD", func = "function"),
+          function(x, func, ascending = TRUE, numPartitions = SparkR::numPartitions(x)) {          
+            values(sortByKey(keyBy(x, func), ascending, numPartitions))
           })
 
 # Helper function to get first N elements from an RDD in the specified order.
 # Param:
-#   rdd An RDD.
+#   x An RDD.
 #   num Number of elements to return.
 #   ascending A flag to indicate whether the sorting is ascending or descending.
 # Return:
 #   A list of the first N elements from the RDD in the specified order.
 #
-takeOrderedElem <- function(rdd, num, ascending = TRUE) {          
+takeOrderedElem <- function(x, num, ascending = TRUE) {          
   if (num <= 0L) {
     return(list())
   }
@@ -1156,13 +1156,13 @@ takeOrderedElem <- function(rdd, num, ascending = TRUE) {
     newElems[ord[1:num]]
   }
   
-  newRdd <- mapPartitions(rdd, partitionFunc)
+  newRdd <- mapPartitions(x, partitionFunc)
   reduce(newRdd, reduceFunc)
 }
 
 #' Returns the first N elements from an RDD in ascending order.
 #'
-#' @param rdd An RDD.
+#' @param x An RDD.
 #' @param num Number of elements to return.
 #' @return The first N elements from the RDD in ascending order.
 #' @rdname takeOrdered
@@ -1173,19 +1173,19 @@ takeOrderedElem <- function(rdd, num, ascending = TRUE) {
 #' rdd <- parallelize(sc, list(10, 1, 2, 9, 3, 4, 5, 6, 7))
 #' takeOrdered(rdd, 6L) # list(1, 2, 3, 4, 5, 6)
 #'}
-setGeneric("takeOrdered", function(rdd, num) { standardGeneric("takeOrdered") })
+setGeneric("takeOrdered", function(x, num) { standardGeneric("takeOrdered") })
 
 #' @rdname takeOrdered
 #' @aliases takeOrdered,RDD,RDD-method
 setMethod("takeOrdered",
-          signature(rdd = "RDD", num = "integer"),
-          function(rdd, num) {          
-            takeOrderedElem(rdd, num)
+          signature(x = "RDD", num = "integer"),
+          function(x, num) {          
+            takeOrderedElem(x, num)
           })
 
 #' Returns the top N elements from an RDD.
 #'
-#' @param rdd An RDD.
+#' @param x An RDD.
 #' @param num Number of elements to return.
 #' @return The top N elements from the RDD.
 #' @rdname top
@@ -1196,14 +1196,14 @@ setMethod("takeOrdered",
 #' rdd <- parallelize(sc, list(10, 1, 2, 9, 3, 4, 5, 6, 7))
 #' top(rdd, 6L) # list(10, 9, 7, 6, 5, 4)
 #'}
-setGeneric("top", function(rdd, num) { standardGeneric("top") })
+setGeneric("top", function(x, num) { standardGeneric("top") })
 
 #' @rdname top
 #' @aliases top,RDD,RDD-method
 setMethod("top",
-          signature(rdd = "RDD", num = "integer"),
-          function(rdd, num) {          
-            takeOrderedElem(rdd, num, FALSE)
+          signature(x = "RDD", num = "integer"),
+          function(x, num) {          
+            takeOrderedElem(x, num, FALSE)
           })
 
 #' Fold an RDD using a given associative function and a neutral "zero value".
@@ -1211,7 +1211,7 @@ setMethod("top",
 #' Aggregate the elements of each partition, and then the results for all the
 #' partitions, using a given associative function and a neutral "zero value".
 #' 
-#' @param rdd An RDD.
+#' @param x An RDD.
 #' @param zeroValue A neutral "zero value".
 #' @param op An associative function for the folding operation.
 #' @return The folding result.
@@ -1224,14 +1224,14 @@ setMethod("top",
 #' rdd <- parallelize(sc, list(1, 2, 3, 4, 5))
 #' fold(rdd, 0, "+") # 15
 #'}
-setGeneric("fold", function(rdd, zeroValue, op) { standardGeneric("fold") })
+setGeneric("fold", function(x, zeroValue, op) { standardGeneric("fold") })
 
 #' @rdname fold
 #' @aliases fold,RDD,RDD-method
 setMethod("fold",
-          signature(rdd = "RDD", zeroValue = "ANY", op = "ANY"),
-          function(rdd, zeroValue, op) {
-            aggregateRDD(rdd, zeroValue, op, op)
+          signature(x = "RDD", zeroValue = "ANY", op = "ANY"),
+          function(x, zeroValue, op) {
+            aggregateRDD(x, zeroValue, op, op)
           })
 
 #' Aggregate an RDD using the given combine functions and a neutral "zero value".
@@ -1239,7 +1239,7 @@ setMethod("fold",
 #' Aggregate the elements of each partition, and then the results for all the
 #' partitions, using given combine functions and a neutral "zero value".
 #' 
-#' @param rdd An RDD.
+#' @param x An RDD.
 #' @param zeroValue A neutral "zero value".
 #' @param seqOp A function to aggregate the RDD elements. It may return a different
 #'              result type from the type of the RDD elements.
@@ -1257,18 +1257,18 @@ setMethod("fold",
 #' combOp <- function(x, y) { list(x[[1]] + y[[1]], x[[2]] + y[[2]]) }
 #' aggregateRDD(rdd, zeroValue, seqOp, combOp) # list(10, 4)
 #'}
-setGeneric("aggregateRDD", function(rdd, zeroValue, seqOp, combOp) { standardGeneric("aggregateRDD") })
+setGeneric("aggregateRDD", function(x, zeroValue, seqOp, combOp) { standardGeneric("aggregateRDD") })
 
 #' @rdname aggregateRDD
 #' @aliases aggregateRDD,RDD,RDD-method
 setMethod("aggregateRDD",
-          signature(rdd = "RDD", zeroValue = "ANY", seqOp = "ANY", combOp = "ANY"),
-          function(rdd, zeroValue, seqOp, combOp) {        
+          signature(x = "RDD", zeroValue = "ANY", seqOp = "ANY", combOp = "ANY"),
+          function(x, zeroValue, seqOp, combOp) {        
             partitionFunc <- function(part) {
               Reduce(seqOp, part, zeroValue)
             }
             
-            partitionList <- collect(lapplyPartition(rdd, partitionFunc),
+            partitionList <- collect(lapplyPartition(x, partitionFunc),
                                      flatten = FALSE)
             Reduce(combOp, partitionList, zeroValue)
           })
@@ -1277,7 +1277,7 @@ setMethod("aggregateRDD",
 #'
 #' The same as 'pipe()' in Spark.
 #'
-#' @param rdd The RDD whose elements are piped to the forked external process.
+#' @param x The RDD whose elements are piped to the forked external process.
 #' @param command The command to fork an external process.
 #' @param env A named list to set environment variables of the external process.
 #' @return A new RDD created by piping all elements to a forked external process.
@@ -1290,15 +1290,15 @@ setMethod("aggregateRDD",
 #' collect(pipeRDD(rdd, "more")
 #' Output: c("1", "2", ..., "10")
 #'}
-setGeneric("pipeRDD", function(rdd, command, env = list()) { 
+setGeneric("pipeRDD", function(x, command, env = list()) { 
   standardGeneric("pipeRDD") 
 })
 
 #' @rdname pipeRDD
 #' @aliases pipeRDD,RDD,character-method
 setMethod("pipeRDD",
-          signature(rdd = "RDD", command = "character"),
-          function(rdd, command, env = list()) {
+          signature(x = "RDD", command = "character"),
+          function(x, command, env = list()) {
             func <- function(part) {
               trim.trailing.func <- function(x) {
                 sub("[\r\n]*$", "", toString(x))
@@ -1307,13 +1307,13 @@ setMethod("pipeRDD",
               res <- system2(command, stdout = TRUE, input = input, env = env)
               lapply(res, trim.trailing.func)
             }
-            lapplyPartition(rdd, func)
+            lapplyPartition(x, func)
           })
 
 # TODO: Consider caching the name in the RDD's environment
 #' Return an RDD's name.
 #'
-#' @param rdd The RDD whose name is returned.
+#' @param x The RDD whose name is returned.
 #' @rdname name
 #' @export
 #' @examples
@@ -1322,19 +1322,19 @@ setMethod("pipeRDD",
 #' rdd <- parallelize(sc, list(1,2,3))
 #' name(rdd) # NULL (if not set before)
 #'}
-setGeneric("name", function(rdd) { standardGeneric("name") })
+setGeneric("name", function(x) { standardGeneric("name") })
 
 #' @rdname name
 #' @aliases name,RDD
 setMethod("name",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            callJMethod(getJRDD(rdd), "name")
+          signature(x = "RDD"),
+          function(x) {
+            callJMethod(getJRDD(x), "name")
           })
 
 #' Set an RDD's name.
 #'
-#' @param rdd The RDD whose name is to be set.
+#' @param x The RDD whose name is to be set.
 #' @param name The RDD name to be set.
 #' @return a new RDD renamed.
 #' @rdname setName
@@ -1346,15 +1346,15 @@ setMethod("name",
 #' setName(rdd, "myRDD")
 #' name(rdd) # "myRDD"
 #'}
-setGeneric("setName", function(rdd, name) { standardGeneric("setName") })
+setGeneric("setName", function(x, name) { standardGeneric("setName") })
 
 #' @rdname setName
 #' @aliases setName,RDD
 setMethod("setName",
-          signature(rdd = "RDD", name = "character"),
-          function(rdd, name) {
-            callJMethod(getJRDD(rdd), "setName", name)
-            rdd
+          signature(x = "RDD", name = "character"),
+          function(x, name) {
+            callJMethod(getJRDD(x), "setName", name)
+            x
           })
 
 ############ Binary Functions #############

--- a/pkg/R/pairRDD.R
+++ b/pkg/R/pairRDD.R
@@ -7,7 +7,7 @@
 #' @description
 #' \code{lookup} returns a list of values in this RDD for key key.
 #'
-#' @param rdd The RDD to collect
+#' @param x The RDD to collect
 #' @param key The key to look up for
 #' @return a list of values in this RDD for key key
 #' @rdname lookup
@@ -19,18 +19,18 @@
 #' rdd <- parallelize(sc, pairs)
 #' lookup(rdd, 1) # list(1, 3)
 #'}
-setGeneric("lookup", function(rdd, key) { standardGeneric("lookup") })
+setGeneric("lookup", function(x, key) { standardGeneric("lookup") })
 
 #' @rdname lookup
 #' @aliases lookup,RDD-method
 setMethod("lookup",
-          signature(rdd = "RDD", key = "ANY"),
-          function(rdd, key) {
+          signature(x = "RDD", key = "ANY"),
+          function(x, key) {
             partitionFunc <- function(part) {
-              filtered <- part[unlist(lapply(part, function(x) { identical(key, x[[1]]) }))]
-              lapply(filtered, function(x) { x[[2]] })
+              filtered <- part[unlist(lapply(part, function(i) { identical(key, i[[1]]) }))]
+              lapply(filtered, function(i) { i[[2]] })
             }
-            valsRDD <- lapplyPartition(rdd, partitionFunc)
+            valsRDD <- lapplyPartition(x, partitionFunc)
             collect(valsRDD)
           })
 
@@ -39,7 +39,7 @@ setMethod("lookup",
 #'
 #' Same as countByKey in Spark.
 #'
-#' @param rdd The RDD to count keys.
+#' @param x The RDD to count keys.
 #' @return list of (key, count) pairs, where count is number of each key in rdd.
 #' @rdname countByKey
 #' @export
@@ -49,20 +49,20 @@ setMethod("lookup",
 #' rdd <- parallelize(sc, list(c("a", 1), c("b", 1), c("a", 1)))
 #' countByKey(rdd) # ("a", 2L), ("b", 1L)
 #'}
-setGeneric("countByKey", function(rdd) { standardGeneric("countByKey") })
+setGeneric("countByKey", function(x) { standardGeneric("countByKey") })
 
 #' @rdname countByKey
 #' @aliases countByKey,RDD-method
 setMethod("countByKey",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            keys <- lapply(rdd, function(item) { item[[1]] })
+          signature(x = "RDD"),
+          function(x) {
+            keys <- lapply(x, function(item) { item[[1]] })
             countByValue(keys)
           })
 
 #' Return an RDD with the keys of each tuple.
 #'
-#' @param rdd The RDD from which the keys of each tuple is returned.
+#' @param x The RDD from which the keys of each tuple is returned.
 #' @rdname keys
 #' @export
 #' @examples
@@ -71,22 +71,22 @@ setMethod("countByKey",
 #' rdd <- parallelize(sc, list(list(1, 2), list(3, 4)))
 #' collect(keys(rdd)) # list(1, 3)
 #'}
-setGeneric("keys", function(rdd) { standardGeneric("keys") })
+setGeneric("keys", function(x) { standardGeneric("keys") })
 
 #' @rdname keys
 #' @aliases keys,RDD
 setMethod("keys",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            func <- function(x) {
-              x[[1]]
+          signature(x = "RDD"),
+          function(x) {
+            func <- function(k) {
+              k[[1]]
             }
-            lapply(rdd, func)
+            lapply(x, func)
           })
 
 #' Return an RDD with the values of each tuple.
 #'
-#' @param rdd The RDD from which the values of each tuple is returned.
+#' @param x The RDD from which the values of each tuple is returned.
 #' @rdname values
 #' @export
 #' @examples
@@ -95,17 +95,17 @@ setMethod("keys",
 #' rdd <- parallelize(sc, list(list(1, 2), list(3, 4)))
 #' collect(values(rdd)) # list(2, 4)
 #'}
-setGeneric("values", function(rdd) { standardGeneric("values") })
+setGeneric("values", function(x) { standardGeneric("values") })
 
 #' @rdname values
 #' @aliases values,RDD
 setMethod("values",
-          signature(rdd = "RDD"),
-          function(rdd) {
-            func <- function(x) {
-              x[[2]]
+          signature(x = "RDD"),
+          function(x) {
+            func <- function(v) {
+              v[[2]]
             }
-            lapply(rdd, func)
+            lapply(x, func)
           })
 
 #' Applies a function to all values of the elements, without modifying the keys.
@@ -176,7 +176,7 @@ setMethod("flatMapValues",
 #' For each element of this RDD, the partitioner is used to compute a hash
 #' function and the RDD is partitioned using this hash value.
 #'
-#' @param rdd The RDD to partition. Should be an RDD where each element is
+#' @param x The RDD to partition. Should be an RDD where each element is
 #'             list(K, V) or c(K, V).
 #' @param numPartitions Number of partitions to create.
 #' @param ... Other optional arguments to partitionBy.
@@ -195,15 +195,15 @@ setMethod("flatMapValues",
 #' collectPartition(parts, 0L) # First partition should contain list(1, 2) and list(1, 4)
 #'}
 setGeneric("partitionBy",
-           function(rdd, numPartitions, ...) {
+           function(x, numPartitions, ...) {
              standardGeneric("partitionBy")
            })
 
 #' @rdname partitionBy
 #' @aliases partitionBy,RDD,integer-method
 setMethod("partitionBy",
-          signature(rdd = "RDD", numPartitions = "integer"),
-          function(rdd, numPartitions, partitionFunc = hashCode) {
+          signature(x = "RDD", numPartitions = "integer"),
+          function(x, numPartitions, partitionFunc = hashCode) {
 
             #if (missing(partitionFunc)) {
             #  partitionFunc <- hashCode
@@ -218,7 +218,7 @@ setMethod("partitionBy",
                                          connection = NULL)
             broadcastArr <- lapply(ls(.broadcastNames), function(name) {
                                    get(name, .broadcastNames) })
-            jrdd <- getJRDD(rdd)
+            jrdd <- getJRDD(x)
 
             # We create a PairwiseRRDD that extends RDD[(Array[Byte],
             # Array[Byte])], where the key is the hashed split, the value is
@@ -227,7 +227,7 @@ setMethod("partitionBy",
                                        callJMethod(jrdd, "rdd"),
                                        as.integer(numPartitions),
                                        serializedHashFuncBytes,
-                                       rdd@env$serialized,
+                                       x@env$serialized,
                                        depsBinArr,
                                        packageNamesArr,
                                        as.character(.sparkREnv$libname),
@@ -254,7 +254,7 @@ setMethod("partitionBy",
 #' This function operates on RDDs where every element is of the form list(K, V) or c(K, V).
 #' and group values for each key in the RDD into a single sequence.
 #'
-#' @param rdd The RDD to group. Should be an RDD where each element is
+#' @param x The RDD to group. Should be an RDD where each element is
 #'             list(K, V) or c(K, V).
 #' @param numPartitions Number of partitions to create.
 #' @return An RDD where each element is list(K, list(V))
@@ -271,27 +271,27 @@ setMethod("partitionBy",
 #' grouped[[1]] # Should be a list(1, list(2, 4))
 #'}
 setGeneric("groupByKey",
-           function(rdd, numPartitions) {
+           function(x, numPartitions) {
              standardGeneric("groupByKey")
            })
 
 #' @rdname groupByKey
 #' @aliases groupByKey,RDD,integer-method
 setMethod("groupByKey",
-          signature(rdd = "RDD", numPartitions = "integer"),
-          function(rdd, numPartitions) {
-            shuffled <- partitionBy(rdd, numPartitions)
+          signature(x = "RDD", numPartitions = "integer"),
+          function(x, numPartitions) {
+            shuffled <- partitionBy(x, numPartitions)
             groupVals <- function(part) {
               vals <- new.env()
               keys <- new.env()
               pred <- function(item) exists(item$hash, keys)
-              appendList <- function(acc, x) {
-                addItemToAccumulator(acc, x)
+              appendList <- function(acc, i) {
+                addItemToAccumulator(acc, i)
                 acc
               }
-              makeList <- function(x) {
+              makeList <- function(i) {
                 acc <- initAccumulator()
-                addItemToAccumulator(acc, x)
+                addItemToAccumulator(acc, i)
                 acc
               }
               # Each item in the partition is list of (K, V)
@@ -303,9 +303,9 @@ setMethod("groupByKey",
                      })
               # extract out data field
               vals <- eapply(vals,
-                             function(x) {
-                               length(x$data) <- x$counter
-                               x$data
+                             function(i) {
+                               length(i$data) <- i$counter
+                               i$data
                              })
               # Every key in the environment contains a list
               # Convert that to list(K, Seq[V])
@@ -319,7 +319,7 @@ setMethod("groupByKey",
 #' This function operates on RDDs where every element is of the form list(K, V) or c(K, V).
 #' and merges the values for each key using an associative reduce function.
 #'
-#' @param rdd The RDD to reduce by key. Should be an RDD where each element is
+#' @param x The RDD to reduce by key. Should be an RDD where each element is
 #'             list(K, V) or c(K, V).
 #' @param combineFunc The associative reduce function to use.
 #' @param numPartitions Number of partitions to create.
@@ -338,15 +338,15 @@ setMethod("groupByKey",
 #' reduced[[1]] # Should be a list(1, 6)
 #'}
 setGeneric("reduceByKey",
-           function(rdd, combineFunc, numPartitions) {
+           function(x, combineFunc, numPartitions) {
              standardGeneric("reduceByKey")
            })
 
 #' @rdname reduceByKey
 #' @aliases reduceByKey,RDD,integer-method
 setMethod("reduceByKey",
-          signature(rdd = "RDD", combineFunc = "ANY", numPartitions = "integer"),
-          function(rdd, combineFunc, numPartitions) {
+          signature(x = "RDD", combineFunc = "ANY", numPartitions = "integer"),
+          function(x, combineFunc, numPartitions) {
             reduceVals <- function(part) {
               vals <- new.env()
               keys <- new.env()
@@ -358,7 +358,7 @@ setMethod("reduceByKey",
                      })
               convertEnvsToList(keys, vals)
             }
-            locallyReduced <- lapplyPartition(rdd, reduceVals)
+            locallyReduced <- lapplyPartition(x, reduceVals)
             shuffled <- partitionBy(locallyReduced, numPartitions)
             lapplyPartition(shuffled, reduceVals)
           })
@@ -369,7 +369,7 @@ setMethod("reduceByKey",
 #' and merges the values for each key using an associative reduce function, but return the
 #' results immediately to the driver as an R list.
 #'
-#' @param rdd The RDD to reduce by key. Should be an RDD where each element is
+#' @param x The RDD to reduce by key. Should be an RDD where each element is
 #'             list(K, V) or c(K, V).
 #' @param combineFunc The associative reduce function to use.
 #' @return A list of elements of type list(K, V') where V' is the merged value for each key
@@ -385,15 +385,15 @@ setMethod("reduceByKey",
 #' reduced # list(list(1, 6), list(1.1, 3))
 #'}
 setGeneric("reduceByKeyLocally",
-           function(rdd, combineFunc) {
+           function(x, combineFunc) {
              standardGeneric("reduceByKeyLocally")
            })
 
 #' @rdname reduceByKeyLocally
 #' @aliases reduceByKeyLocally,RDD,integer-method
 setMethod("reduceByKeyLocally",
-          signature(rdd = "RDD", combineFunc = "ANY"),
-          function(rdd, combineFunc) {
+          signature(x = "RDD", combineFunc = "ANY"),
+          function(x, combineFunc) {
             reducePart <- function(part) {
               vals <- new.env()
               keys <- new.env()
@@ -417,7 +417,7 @@ setMethod("reduceByKeyLocally",
                      })
               accum
             }
-            reduced <- mapPartitions(rdd, reducePart)
+            reduced <- mapPartitions(x, reducePart)
             merged <- reduce(reduced, mergeParts)
             convertEnvsToList(merged[[1]], merged[[2]])
           })
@@ -437,7 +437,7 @@ setMethod("reduceByKeyLocally",
 #'    two lists).
 #' }
 #'
-#' @param rdd The RDD to combine. Should be an RDD where each element is
+#' @param x The RDD to combine. Should be an RDD where each element is
 #'             list(K, V) or c(K, V).
 #' @param createCombiner Create a combiner (C) given a value (V)
 #' @param mergeValue Merge the given value (V) with an existing combiner (C)
@@ -458,16 +458,16 @@ setMethod("reduceByKeyLocally",
 #' combined[[1]] # Should be a list(1, 6)
 #'}
 setGeneric("combineByKey",
-           function(rdd, createCombiner, mergeValue, mergeCombiners, numPartitions) {
+           function(x, createCombiner, mergeValue, mergeCombiners, numPartitions) {
              standardGeneric("combineByKey")
            })
 
 #' @rdname combineByKey
 #' @aliases combineByKey,RDD,ANY,ANY,ANY,integer-method
 setMethod("combineByKey",
-          signature(rdd = "RDD", createCombiner = "ANY", mergeValue = "ANY",
+          signature(x = "RDD", createCombiner = "ANY", mergeValue = "ANY",
                     mergeCombiners = "ANY", numPartitions = "integer"),
-          function(rdd, createCombiner, mergeValue, mergeCombiners, numPartitions) {
+          function(x, createCombiner, mergeValue, mergeCombiners, numPartitions) {
             combineLocally <- function(part) {
               combiners <- new.env()
               keys <- new.env()
@@ -479,7 +479,7 @@ setMethod("combineByKey",
                      })
               convertEnvsToList(keys, combiners)
             }
-            locallyCombined <- lapplyPartition(rdd, combineLocally)
+            locallyCombined <- lapplyPartition(x, combineLocally)
             shuffled <- partitionBy(locallyCombined, numPartitions)
             mergeAfterShuffle <- function(part) {
               combiners <- new.env()
@@ -506,7 +506,7 @@ setMethod("combineByKey",
 #' of these functions are allowed to modify and return their first argument 
 #' instead of creating a new U.
 #' 
-#' @param rdd An RDD.
+#' @param x An RDD.
 #' @param zeroValue A neutral "zero value".
 #' @param seqOp A function to aggregate the values of each key. It may return 
 #'              a different result type from the type of the values.
@@ -526,21 +526,21 @@ setMethod("combineByKey",
 #'   # list(list(1, list(3, 2)), list(2, list(7, 2)))
 #'}
 setGeneric("aggregateByKey",
-           function(rdd, zeroValue, seqOp, combOp, numPartitions) {
+           function(x, zeroValue, seqOp, combOp, numPartitions) {
              standardGeneric("aggregateByKey")
            })
 
 #' @rdname aggregateByKey
 #' @aliases aggregateByKey,RDD,ANY,ANY,ANY,integer-method
 setMethod("aggregateByKey",
-          signature(rdd = "RDD", zeroValue = "ANY", seqOp = "ANY",
+          signature(x = "RDD", zeroValue = "ANY", seqOp = "ANY",
                     combOp = "ANY", numPartitions = "integer"),
-          function(rdd, zeroValue, seqOp, combOp, numPartitions) {
+          function(x, zeroValue, seqOp, combOp, numPartitions) {
             createCombiner <- function(v) {
               do.call(seqOp, list(zeroValue, v))
             }
 
-            combineByKey(rdd, createCombiner, seqOp, combOp, numPartitions)
+            combineByKey(x, createCombiner, seqOp, combOp, numPartitions)
           })
 
 #' Fold a pair RDD by each key.
@@ -550,7 +550,7 @@ setMethod("aggregateByKey",
 #' number of times, and must not change the result (e.g., 0 for addition, or 
 #' 1 for multiplication.).
 #' 
-#' @param rdd An RDD.
+#' @param x An RDD.
 #' @param zeroValue A neutral "zero value".
 #' @param func An associative function for folding values of each key.
 #' @return An RDD containing the aggregation result.
@@ -564,17 +564,17 @@ setMethod("aggregateByKey",
 #' foldByKey(rdd, 0, "+", 2L) # list(list(1, 3), list(2, 7))
 #'}
 setGeneric("foldByKey",
-           function(rdd, zeroValue, func, numPartitions) {
+           function(x, zeroValue, func, numPartitions) {
              standardGeneric("foldByKey")
            })
 
 #' @rdname foldByKey
 #' @aliases foldByKey,RDD,ANY,ANY,integer-method
 setMethod("foldByKey",
-          signature(rdd = "RDD", zeroValue = "ANY",
+          signature(x = "RDD", zeroValue = "ANY",
                     func = "ANY", numPartitions = "integer"),
-          function(rdd, zeroValue, func, numPartitions) {
-            aggregateByKey(rdd, zeroValue, func, func, numPartitions)
+          function(x, zeroValue, func, numPartitions) {
+            aggregateByKey(x, zeroValue, func, func, numPartitions)
           })
 
 ############ Binary Functions #############
@@ -585,9 +585,9 @@ setMethod("foldByKey",
 #' \code{join} This function joins two RDDs where every element is of the form list(K, V).
 #' The key types of the two RDDs should be the same.
 #'
-#' @param rdd1 An RDD to be joined. Should be an RDD where each element is
+#' @param x An RDD to be joined. Should be an RDD where each element is
 #'             list(K, V).
-#' @param rdd2 An RDD to be joined. Should be an RDD where each element is
+#' @param y An RDD to be joined. Should be an RDD where each element is
 #'             list(K, V).
 #' @param numPartitions Number of partitions to create.
 #' @return a new RDD containing all pairs of elements with matching keys in
@@ -601,21 +601,21 @@ setMethod("foldByKey",
 #' rdd2 <- parallelize(sc, list(list(1, 2), list(1, 3)))
 #' join(rdd1, rdd2, 2L) # list(list(1, list(1, 2)), list(1, list(1, 3))
 #'}
-setGeneric("join", function(rdd1, rdd2, numPartitions) { standardGeneric("join") })
+setGeneric("join", function(x, y, numPartitions) { standardGeneric("join") })
 
 #' @rdname join-methods
 #' @aliases join,RDD,RDD-method
 setMethod("join",
-          signature(rdd1 = "RDD", rdd2 = "RDD", numPartitions = "integer"),
-          function(rdd1, rdd2, numPartitions) {
-            rdd1Tagged <- lapply(rdd1, function(x) { list(x[[1]], list(1L, x[[2]])) })
-            rdd2Tagged <- lapply(rdd2, function(x) { list(x[[1]], list(2L, x[[2]])) })
+          signature(x = "RDD", y = "RDD", numPartitions = "integer"),
+          function(x, y, numPartitions) {
+            xTagged <- lapply(x, function(i) { list(i[[1]], list(1L, i[[2]])) })
+            yTagged <- lapply(y, function(i) { list(i[[1]], list(2L, i[[2]])) })
             
             doJoin <- function(v) {
               joinTaggedList(v, list(FALSE, FALSE))
             }
             
-            joined <- flatMapValues(groupByKey(unionRDD(rdd1Tagged, rdd2Tagged), numPartitions), doJoin)
+            joined <- flatMapValues(groupByKey(unionRDD(xTagged, yTagged), numPartitions), doJoin)
           })
 
 #' Left outer join two RDDs
@@ -624,12 +624,12 @@ setMethod("join",
 #' \code{leftouterjoin} This function left-outer-joins two RDDs where every element is of the form list(K, V).
 #' The key types of the two RDDs should be the same.
 #'
-#' @param rdd1 An RDD to be joined. Should be an RDD where each element is
+#' @param x An RDD to be joined. Should be an RDD where each element is
 #'             list(K, V).
-#' @param rdd2 An RDD to be joined. Should be an RDD where each element is
+#' @param y An RDD to be joined. Should be an RDD where each element is
 #'             list(K, V).
 #' @param numPartitions Number of partitions to create.
-#' @return For each element (k, v) in rdd1, the resulting RDD will either contain 
+#' @return For each element (k, v) in x, the resulting RDD will either contain 
 #'         all pairs (k, (v, w)) for (k, w) in rdd2, or the pair (k, (v, NULL)) 
 #'         if no elements in rdd2 have key k.
 #' @rdname join-methods
@@ -642,21 +642,21 @@ setMethod("join",
 #' leftOuterJoin(rdd1, rdd2, 2L)
 #' # list(list(1, list(1, 2)), list(1, list(1, 3)), list(2, list(4, NULL)))
 #'}
-setGeneric("leftOuterJoin", function(rdd1, rdd2, numPartitions) { standardGeneric("leftOuterJoin") })
+setGeneric("leftOuterJoin", function(x, y, numPartitions) { standardGeneric("leftOuterJoin") })
 
 #' @rdname join-methods
 #' @aliases leftOuterJoin,RDD,RDD-method
 setMethod("leftOuterJoin",
-          signature(rdd1 = "RDD", rdd2 = "RDD", numPartitions = "integer"),
-          function(rdd1, rdd2, numPartitions) {
-            rdd1Tagged <- lapply(rdd1, function(x) { list(x[[1]], list(1L, x[[2]])) })
-            rdd2Tagged <- lapply(rdd2, function(x) { list(x[[1]], list(2L, x[[2]])) })
+          signature(x = "RDD", y = "RDD", numPartitions = "integer"),
+          function(x, y, numPartitions) {
+            xTagged <- lapply(x, function(i) { list(i[[1]], list(1L, i[[2]])) })
+            yTagged <- lapply(y, function(i) { list(i[[1]], list(2L, i[[2]])) })
             
             doJoin <- function(v) {
               joinTaggedList(v, list(FALSE, TRUE))
             }
             
-            joined <- flatMapValues(groupByKey(unionRDD(rdd1Tagged, rdd2Tagged), numPartitions), doJoin)
+            joined <- flatMapValues(groupByKey(unionRDD(xTagged, yTagged), numPartitions), doJoin)
           })
 
 #' Right outer join two RDDs
@@ -665,14 +665,14 @@ setMethod("leftOuterJoin",
 #' \code{rightouterjoin} This function right-outer-joins two RDDs where every element is of the form list(K, V).
 #' The key types of the two RDDs should be the same.
 #'
-#' @param rdd1 An RDD to be joined. Should be an RDD where each element is
+#' @param x An RDD to be joined. Should be an RDD where each element is
 #'             list(K, V).
-#' @param rdd2 An RDD to be joined. Should be an RDD where each element is
+#' @param y An RDD to be joined. Should be an RDD where each element is
 #'             list(K, V).
 #' @param numPartitions Number of partitions to create.
-#' @return For each element (k, w) in rdd2, the resulting RDD will either contain
-#'         all pairs (k, (v, w)) for (k, v) in rdd1, or the pair (k, (NULL, w))
-#'         if no elements in rdd1 have key k.
+#' @return For each element (k, w) in y, the resulting RDD will either contain
+#'         all pairs (k, (v, w)) for (k, v) in x, or the pair (k, (NULL, w))
+#'         if no elements in x have key k.
 #' @rdname join-methods
 #' @export
 #' @examples
@@ -683,21 +683,21 @@ setMethod("leftOuterJoin",
 #' rightOuterJoin(rdd1, rdd2, 2L)
 #' # list(list(1, list(2, 1)), list(1, list(3, 1)), list(2, list(NULL, 4)))
 #'}
-setGeneric("rightOuterJoin", function(rdd1, rdd2, numPartitions) { standardGeneric("rightOuterJoin") })
+setGeneric("rightOuterJoin", function(x, y, numPartitions) { standardGeneric("rightOuterJoin") })
 
 #' @rdname join-methods
 #' @aliases rightOuterJoin,RDD,RDD-method
 setMethod("rightOuterJoin",
-          signature(rdd1 = "RDD", rdd2 = "RDD", numPartitions = "integer"),
-          function(rdd1, rdd2, numPartitions) {
-            rdd1Tagged <- lapply(rdd1, function(x) { list(x[[1]], list(1L, x[[2]])) })
-            rdd2Tagged <- lapply(rdd2, function(x) { list(x[[1]], list(2L, x[[2]])) })
+          signature(x = "RDD", y = "RDD", numPartitions = "integer"),
+          function(x, y, numPartitions) {
+            xTagged <- lapply(x, function(i) { list(i[[1]], list(1L, i[[2]])) })
+            yTagged <- lapply(y, function(i) { list(i[[1]], list(2L, i[[2]])) })
             
             doJoin <- function(v) {
               joinTaggedList(v, list(TRUE, FALSE))
             }
             
-            joined <- flatMapValues(groupByKey(unionRDD(rdd1Tagged, rdd2Tagged), numPartitions), doJoin)
+            joined <- flatMapValues(groupByKey(unionRDD(xTagged, yTagged), numPartitions), doJoin)
           })
 
 #' Full outer join two RDDs
@@ -706,15 +706,15 @@ setMethod("rightOuterJoin",
 #' \code{fullouterjoin} This function full-outer-joins two RDDs where every element is of the form list(K, V). 
 #' The key types of the two RDDs should be the same.
 #'
-#' @param rdd1 An RDD to be joined. Should be an RDD where each element is
+#' @param x An RDD to be joined. Should be an RDD where each element is
 #'             list(K, V).
-#' @param rdd2 An RDD to be joined. Should be an RDD where each element is
+#' @param y An RDD to be joined. Should be an RDD where each element is
 #'             list(K, V).
 #' @param numPartitions Number of partitions to create.
-#' @return For each element (k, v) in rdd1 and (k, w) in rdd2, the resulting RDD
-#'         will contain all pairs (k, (v, w)) for both (k, v) in rdd1 and and
-#'         (k, w) in rdd2, or the pair (k, (NULL, w))/(k, (v, NULL)) if no elements 
-#'         in rdd1/rdd2 have key k.
+#' @return For each element (k, v) in x and (k, w) in y, the resulting RDD
+#'         will contain all pairs (k, (v, w)) for both (k, v) in x and
+#'         (k, w) in y, or the pair (k, (NULL, w))/(k, (v, NULL)) if no elements 
+#'         in x/y have key k.
 #' @rdname join-methods
 #' @export
 #' @examples
@@ -727,22 +727,22 @@ setMethod("rightOuterJoin",
 #'                               #      list(2, list(NULL, 4)))
 #'                               #      list(3, list(3, NULL)),
 #'}
-setGeneric("fullOuterJoin", function(rdd1, rdd2, numPartitions) { standardGeneric("fullOuterJoin") })
+setGeneric("fullOuterJoin", function(x, y, numPartitions) { standardGeneric("fullOuterJoin") })
 
 #' @rdname join-methods
 #' @aliases fullOuterJoin,RDD,RDD-method
 
 setMethod("fullOuterJoin",
-          signature(rdd1 = "RDD", rdd2 = "RDD", numPartitions = "integer"),
-          function(rdd1, rdd2, numPartitions) {
-            rdd1Tagged <- lapply(rdd1, function(x) { list(x[[1]], list(1L, x[[2]])) })
-            rdd2Tagged <- lapply(rdd2, function(x) { list(x[[1]], list(2L, x[[2]])) })
+          signature(x = "RDD", y = "RDD", numPartitions = "integer"),
+          function(x, y, numPartitions) {
+            xTagged <- lapply(x, function(i) { list(i[[1]], list(1L, i[[2]])) })
+            yTagged <- lapply(y, function(i) { list(i[[1]], list(2L, i[[2]])) })
 
             doJoin <- function(v) {
               joinTaggedList(v, list(TRUE, TRUE))
             }
 
-            joined <- flatMapValues(groupByKey(unionRDD(rdd1Tagged, rdd2Tagged), numPartitions), doJoin)
+            joined <- flatMapValues(groupByKey(unionRDD(xTagged, yTagged), numPartitions), doJoin)
           })
 
 #' For each key k in several RDDs, return a resulting RDD that
@@ -809,7 +809,7 @@ setMethod("cogroup",
 
 #' Sort a (k, v) pair RDD by k.
 #'
-#' @param rdd A (k, v) pair RDD to be sorted.
+#' @param x A (k, v) pair RDD to be sorted.
 #' @param ascending A flag to indicate whether the sorting is ascending or descending.
 #' @param numPartitions Number of partitions to create.
 #' @return An RDD where all (k, v) pair elements are sorted.
@@ -821,7 +821,7 @@ setMethod("cogroup",
 #' rdd <- parallelize(sc, list(list(3, 1), list(2, 2), list(1, 3)))
 #' collect(sortByKey(rdd)) # list (list(1, 3), list(2, 2), list(3, 1))
 #'}
-setGeneric("sortByKey", function(rdd,
+setGeneric("sortByKey", function(x,
                                  ascending = TRUE,
                                  numPartitions = 1L) {
                           standardGeneric("sortByKey")
@@ -830,17 +830,17 @@ setGeneric("sortByKey", function(rdd,
 #' @rdname sortByKey
 #' @aliases sortByKey,RDD,RDD-method
 setMethod("sortByKey",
-          signature(rdd = "RDD"),
-          function(rdd, ascending = TRUE, numPartitions = SparkR::numPartitions(rdd)) {
+          signature(x = "RDD"),
+          function(x, ascending = TRUE, numPartitions = SparkR::numPartitions(x)) {
             rangeBounds <- list()
             
             if (numPartitions > 1) {
-              rddSize <- count(rdd)
+              rddSize <- count(x)
               # constant from Spark's RangePartitioner
               maxSampleSize <- numPartitions * 20
               fraction <- min(maxSampleSize / max(rddSize, 1), 1.0)
               
-              samples <- collect(keys(sampleRDD(rdd, FALSE, fraction, 1L)))
+              samples <- collect(keys(sampleRDD(x, FALSE, fraction, 1L)))
               
               # Note: the built-in R sort() function only works on atomic vectors
               samples <- sort(unlist(samples, recursive = FALSE), decreasing = !ascending)
@@ -873,7 +873,7 @@ setMethod("sortByKey",
               sortKeyValueList(part, decreasing = !ascending)
             }
             
-            newRDD <- partitionBy(rdd, numPartitions, rangePartitionFunc)
+            newRDD <- partitionBy(x, numPartitions, rangePartitionFunc)
             lapplyPartition(newRDD, partitionFunc)
           })
           


### PR DESCRIPTION
Replace the `rdd` argument in all of the S4 methods with `x`. This will allow us to standardize the code as other Spark components get added and we need to set up multiple dispatch on S4 methods.

In any cases where `x` was used as a generic iterator, I've replaced it with `i` except in a few cases where a different letter made sense. For example, in some of the pair functions, we now use `function(k)` and `function(v)` for the key/value functions.