### PR TITLE
[SPARKR-155] use socket in R worker

### DIFF
--- a/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
+++ b/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
@@ -7,13 +7,13 @@ import java.util.{Map => JMap}
 import scala.collection.JavaConversions._
 import scala.io.Source
 import scala.reflect.ClassTag
+import scala.util.Try
 
 import org.apache.spark.{SparkEnv, Partition, SparkException, TaskContext, SparkConf}
 import org.apache.spark.api.java.{JavaSparkContext, JavaRDD, JavaPairRDD}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 
-import scala.util.Try
 
 private abstract class BaseRRDD[T: ClassTag, U: ClassTag](
     parent: RDD[T],


### PR DESCRIPTION
This PR will use socket to send and receive result from R worker. 

The reason we can not use stdin/stdout is that we plan to have daemon to launch the R worker,  then the stdin/stdout can not accessible from JVM.