### PR TITLE
Three more DataFrame methods

### DIFF
--- a/pkg/NAMESPACE
+++ b/pkg/NAMESPACE
@@ -85,6 +85,7 @@ importFrom(methods, setGeneric, setMethod, setOldClass)
 exportClasses("DataFrame")
 
 exportMethods("columns",
+              "distinct",
               "dtypes",
               "first",
               "head",
@@ -92,6 +93,8 @@ exportMethods("columns",
               "names",
               "printSchema",
               "registerTempTable",
+              "repartition",
+              "sampleDF",
               "schema",
               "toRDD")
 

--- a/pkg/R/DataFrame.R
+++ b/pkg/R/DataFrame.R
@@ -275,9 +275,9 @@ setGeneric("repartition", function(x, numPartitions) { standardGeneric("repartit
 #' @rdname repartition
 #' @export
 setMethod("repartition",
-          signature(x = "DataFrame", numPartitions = "integer"),
+          signature(x = "DataFrame", numPartitions = "numeric"),
           function(x, numPartitions) {
-            sdf <- callJMethod(x@sdf, "repartition", as.integer(numPartitions))
+            sdf <- callJMethod(x@sdf, "repartition", numToInt(numPartitions))
             dataFrame(sdf)     
           })
 

--- a/pkg/R/DataFrame.R
+++ b/pkg/R/DataFrame.R
@@ -335,7 +335,7 @@ setMethod("sampleDF",
           # TODO : Figure out how to send integer as java.lang.Long to JVM so
           # we can send seed as an argument through callJMethod
           signature(x = "DataFrame", withReplacement = "logical",
-                      fraction = "numeric"),
+                    fraction = "numeric"),
           function(x, withReplacement, fraction) {
             if (fraction < 0.0) stop(cat("Negative fraction value:", fraction))
             sdf <- callJMethod(x@sdf, "sample", withReplacement, fraction)

--- a/pkg/R/DataFrame.R
+++ b/pkg/R/DataFrame.R
@@ -253,6 +253,96 @@ setMethod("unpersist",
             x
           })
 
+#' Repartition
+#'
+#' Return a new DataFrame that has exactly numPartitions partitions.
+#'
+#' @param x A SparkSQL DataFrame
+#' @param numPartitions The number of partitions to use.
+#' @rdname repartition
+#' @export
+#' @examples
+#'\dontrun{
+#' sc <- sparkR.init()
+#' sqlCtx <- sparkRSQL.init(sc)
+#' path <- "path/to/file.json"
+#' df <- jsonFile(sqlCtx, path)
+#' newDF <- repartition(df, 2L)
+#'}
+
+setGeneric("repartition", function(x, numPartitions) { standardGeneric("repartition") })
+
+#' @rdname repartition
+#' @export
+setMethod("repartition",
+          signature(x = "DataFrame", numPartitions = "integer"),
+          function(x, numPartitions) {
+            sdf <- callJMethod(x@sdf, "repartition", as.integer(numPartitions))
+            dataFrame(sdf)     
+            })
+
+#' Distinct
+#'
+#' Return a new DataFrame containing the distinct rows in this DataFrame.
+#'
+#' @param x A SparkSQL DataFrame
+#' @rdname distinct
+#' @export
+#' @examples
+#'\dontrun{
+#' sc <- sparkR.init()
+#' sqlCtx <- sparkRSQL.init(sc)
+#' path <- "path/to/file.json"
+#' df <- jsonFile(sqlCtx, path)
+#' distinctDF <- distinct(df)
+#'}
+
+setMethod("distinct",
+          signature(x = "DataFrame"),
+          function(x) {
+            sdf <- callJMethod(x@sdf, "distinct")
+            dataFrame(sdf)
+            })
+
+#' SampleDF
+#'
+#' Return a sampled subset of this DataFrame using a random seed.
+#'
+#' @param x A SparkSQL DataFrame
+#' @param withReplacement Sampling with replacement or not
+#' @param fraction The (rough) sample target fraction
+#' @param seed Randomness seed value
+#' @rdname sampleDF
+#' @export
+#' @examples
+#'\dontrun{
+#' sc <- sparkR.init()
+#' sqlCtx <- sparkRSQL.init(sc)
+#' path <- "path/to/file.json"
+#' df <- jsonFile(sqlCtx, path)
+#' collect(sampleRDD(rdd, FALSE, 0.5, 1618L)) 
+#' collect(sampleRDD(rdd, TRUE, 0.5, 9L))
+#'}
+
+setGeneric("sampleDF",
+           function(x, withReplacement, fraction, seed) {
+             standardGeneric("sampleDF")
+          })
+
+#' @rdname sampleDF
+#' @export
+
+setMethod("sampleDF",
+          # TODO : Figure out how to send integer as java.lang.Long to JVM so
+          # we can send seed as an argument through callJMethod
+          signature(x = "DataFrame", withReplacement = "logical",
+                      fraction = "numeric"),
+          function(x, withReplacement, fraction) {
+            if (fraction < 0.0) stop(cat("Negative fraction value:", fraction))
+            sdf <- callJMethod(x@sdf, "sample", withReplacement, fraction)
+            dataFrame(sdf)
+          })
+
 #' Count
 #' 
 #' Returns the number of rows in a DataFrame

--- a/pkg/R/DataFrame.R
+++ b/pkg/R/DataFrame.R
@@ -279,7 +279,7 @@ setMethod("repartition",
           function(x, numPartitions) {
             sdf <- callJMethod(x@sdf, "repartition", as.integer(numPartitions))
             dataFrame(sdf)     
-            })
+          })
 
 #' Distinct
 #'
@@ -302,7 +302,7 @@ setMethod("distinct",
           function(x) {
             sdf <- callJMethod(x@sdf, "distinct")
             dataFrame(sdf)
-            })
+          })
 
 #' SampleDF
 #'
@@ -311,7 +311,6 @@ setMethod("distinct",
 #' @param x A SparkSQL DataFrame
 #' @param withReplacement Sampling with replacement or not
 #' @param fraction The (rough) sample target fraction
-#' @param seed Randomness seed value
 #' @rdname sampleDF
 #' @export
 #' @examples
@@ -320,8 +319,8 @@ setMethod("distinct",
 #' sqlCtx <- sparkRSQL.init(sc)
 #' path <- "path/to/file.json"
 #' df <- jsonFile(sqlCtx, path)
-#' collect(sampleRDD(rdd, FALSE, 0.5, 1618L)) 
-#' collect(sampleRDD(rdd, TRUE, 0.5, 9L))
+#' collect(sampleDF(df, FALSE, 0.5)) 
+#' collect(sampleDF(df, TRUE, 0.5))
 #'}
 
 setGeneric("sampleDF",

--- a/pkg/R/utils.R
+++ b/pkg/R/utils.R
@@ -326,3 +326,11 @@ getStorageLevel <- function(newLevel = c("DISK_ONLY",
                          "OFF_HEAP" = SparkR:::callJStatic("org.apache.spark.storage.StorageLevel", "OFF_HEAP"))
 }
 
+# Utility function for functions where an argument needs to be integer but we want to allow
+# the user to type (for example) `5` instead of `5L` to avoid a confusing error message.
+numToInt <- function(num) {
+  if (as.integer(num) != num) {
+    warning(paste("Coercing", as.list(sys.call())[[2]], "to integer."))
+  }
+  as.integer(num)
+}

--- a/pkg/inst/tests/test_sparkSQL.R
+++ b/pkg/inst/tests/test_sparkSQL.R
@@ -216,6 +216,8 @@ test_that("sampleDF on a DataFrame", {
   sampled <- sampleDF(df, FALSE, 1.0)
   expect_equal(nrow(collect(sampled)), count(df))
   expect_true(inherits(sampled, "DataFrame"))
+  sampled2 <- sampleDF(df, FALSE, 0.1)
+  expect_true(count(sampled2) < 3)
 })
 
 unlink(jsonPath)

--- a/pkg/inst/tests/test_sparkSQL.R
+++ b/pkg/inst/tests/test_sparkSQL.R
@@ -197,4 +197,25 @@ test_that("head() and first() return the correct data", {
   expect_true(nrow(testFirst) == 1)
 })
 
+test_that("distinct() on DataFrames", {
+  lines <- c("{\"name\":\"Michael\"}",
+             "{\"name\":\"Andy\", \"age\":30}",
+             "{\"name\":\"Justin\", \"age\":19}",
+             "{\"name\":\"Justin\", \"age\":19}")
+  jsonPathWithDup <- tempfile(pattern="sparkr-test", fileext=".tmp")
+  writeLines(lines, jsonPathWithDup)
+  
+  df <- jsonFile(sqlCtx, jsonPathWithDup)
+  uniques <- distinct(df)
+  expect_true(inherits(uniques, "DataFrame"))
+  expect_true(count(uniques) == 3)
+})
+
+test_that("sampleDF on a DataFrame", {
+  df <- jsonFile(sqlCtx, jsonPath)
+  sampled <- sampleDF(df, FALSE, 1.0)
+  expect_equal(nrow(collect(sampled)), count(df))
+  expect_true(inherits(sampled, "DataFrame"))
+})
+
 unlink(jsonPath)


### PR DESCRIPTION
- `repartition`
- `distinct`
- `sampleDF`

`sampleDF` currently only uses the random seed version. It seems that in order to be able to set the seed manually, we'll need to be able to pass a Long type through `callJMethod` first. That can be expanded later unless someone already has it figured out.