### PR TITLE
Fix stderr redirection on executors

### DIFF
--- a/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
+++ b/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
@@ -37,7 +37,7 @@ private abstract class BaseRRDD[T: ClassTag, U: ClassTag](
     val listenPort = serverSocket.getLocalPort()
 
     val pb = rWorkerProcessBuilder(listenPort)
-    pb.redirectErrorStream()  // redirect stderr into stdout
+    pb.redirectErrorStream(true)  // redirect stderr into stdout
     val proc = pb.start()
     val errThread =  startStdoutThread(proc)
 


### PR DESCRIPTION
Calling `redirectErrorStream` without any arguments only tests whether stderr is redirected to stdout. JavaDoc at http://docs.oracle.com/javase/7/docs/api/java/lang/ProcessBuilder.html#redirectErrorStream() explains this

cc @davies 