### PR TITLE
[SPARKR-214] launch R worker by a daemon

### DIFF
--- a/pkg/inst/worker/daemon.R
+++ b/pkg/inst/worker/daemon.R
@@ -1,7 +1,13 @@
 # Worker daemon
 
+# try to load `fork`, or install
+FORK_URI <- "http://cran.r-project.org/src/contrib/Archive/fork/fork_1.2.4.tar.gz"
+tryCatch(library(fork), error = function(err) {
+  install.packages(FORK_URI, repos = NULL, type = "source")
+})
+
 rLibDir <- Sys.getenv("SPARKR_RLIBDIR")
-script <- paste(rLibDir, "SparkR/worker/worker.R", sep="/")
+script <- paste(rLibDir, "SparkR/worker/worker.R", sep = "/")
 
 # preload SparkR package, speedup worker
 .libPaths(c(rLibDir, .libPaths()))
@@ -11,15 +17,23 @@ port <- as.integer(Sys.getenv("SPARKR_WORKER_PORT"))
 inputCon <- socketConnection(port = port, blocking = TRUE, open = "rb")
 
 while (TRUE) {
-  inport <- SparkR:::readInt(inputCon)
-  if (length(inport) != 1) {
-    quit(save="no")
+  ready <- socketSelect(list(inputCon), timeout = 1)
+  if (ready) {
+    inport <- SparkR:::readInt(inputCon)
+    if (length(inport) != 1) {
+      quit(save="no")
+    }
+    p <- fork::fork(NULL)
+    if (p == 0) {
+      close(inputCon)
+      Sys.setenv(SPARKR_WORKER_PORT = inport)
+      source(script)
+      fork::exit(0)
+    }
   }
-  p <- parallel:::mcfork()
-  if (inherits(p, "masterProcess")) {
-    close(inputCon)
-    Sys.setenv(SPARKR_WORKER_PORT = inport)
-    source(script)
-    parallel:::mcexit(0)
+  # cleanup all the child process
+  status <- fork::wait(0, nohang = TRUE)
+  while (status[1] > 0) {
+    status <- fork::wait(0, nohang = TRUE)
   }
 }

--- a/pkg/inst/worker/daemon.R
+++ b/pkg/inst/worker/daemon.R
@@ -14,9 +14,13 @@ while (TRUE) {
   ready <- socketSelect(list(inputCon))
   if (ready) {
     port <- SparkR:::readInt(inputCon)
+    # There is a small chance that it could be interrupted by signal, retry one time
     if (length(port) == 0) {
-      cat("quitting daemon", "\n")
-      quit(save = "no")
+      port <- SparkR:::readInt(inputCon)
+      if (length(port) == 0) {
+        cat("quitting daemon\n")
+        quit(save = "no")
+      }
     }
     p <- parallel:::mcfork()
     if (inherits(p, "masterProcess")) {

--- a/pkg/inst/worker/daemon.R
+++ b/pkg/inst/worker/daemon.R
@@ -10,48 +10,22 @@ suppressPackageStartupMessages(library(SparkR))
 port <- as.integer(Sys.getenv("SPARKR_WORKER_PORT"))
 inputCon <- socketConnection(port = port, open = "rb", blocking = TRUE, timeout = 3600)
 
-# Read from connection, retrying to read exactly 'size' bytes
-readBinFull <- function(con, size) {
-  # readBin() could be interruptted by signal, we have no way to tell
-  # if it's interruptted or the socket is closed, so we retry at most
-  # 20 times, to avoid the deadloop if the socket is closed
-  c <- 1
-  data <- readBin(con, raw(), size)
-  while (length(data) < size && c < 20) {
-    extra <- readBin(con, raw(), size - length(data))
-    data <- c(data, extra)
-    c <- c + 1
-  }
-  data
-}
-
-# Utility function to read the port with retry
-# Returns -1 if the socket was closed
-readPort <- function(con) {
-  data <- readBinFull(con, 4L)
-  if (length(data) != 4) {
-    -1
-  } else {
-    rc <- rawConnection(data)
-    ret <- SparkR:::readInt(rc)
-    close(rc)
-    ret
-  }
-}
-
 while (TRUE) {
-  port <- readPort(inputCon)
-  if (port < 0) {
-    cat("quitting daemon\n")
-    quit(save = "no")
-  }
-  p <- parallel:::mcfork()
-  if (inherits(p, "masterProcess")) {
-    close(inputCon)
-    Sys.setenv(SPARKR_WORKER_PORT = port)
-    source(script)
-    # Set SIGUSR1 so that child can exit
-    tools::pskill(Sys.getpid(), tools::SIGUSR1)
-    parallel:::mcexit(0L)
+  ready <- socketSelect(list(inputCon))
+  if (ready) {
+    port <- SparkR:::readInt(inputCon)
+    if (length(port) == 0) {
+      cat("quitting daemon", "\n")
+      quit(save = "no")
+    }
+    p <- parallel:::mcfork()
+    if (inherits(p, "masterProcess")) {
+      close(inputCon)
+      Sys.setenv(SPARKR_WORKER_PORT = port)
+      source(script)
+      # Set SIGUSR1 so that child can exit
+      tools::pskill(Sys.getpid(), tools::SIGUSR1)
+      parallel:::mcexit(0L)
+    }
   }
 }

--- a/pkg/inst/worker/daemon.R
+++ b/pkg/inst/worker/daemon.R
@@ -1,0 +1,25 @@
+# Worker daemon
+
+rLibDir <- Sys.getenv("SPARKR_RLIBDIR")
+script <- paste(rLibDir, "SparkR/worker/worker.R", sep="/")
+
+# preload SparkR package, speedup worker
+.libPaths(c(rLibDir, .libPaths()))
+suppressPackageStartupMessages(library(SparkR))
+
+port <- as.integer(Sys.getenv("SPARKR_WORKER_PORT"))
+inputCon <- socketConnection(port = port, blocking = TRUE, open = "rb")
+
+while (TRUE) {
+  inport <- SparkR:::readInt(inputCon)
+  if (length(inport) != 1) {
+    quit(save="no")
+  }
+  p <- parallel:::mcfork()
+  if (inherits(p, "masterProcess")) {
+    close(inputCon)
+    Sys.setenv(SPARKR_WORKER_PORT = inport)
+    source(script)
+    parallel:::mcexit(0)
+  }
+}

--- a/pkg/inst/worker/worker.R
+++ b/pkg/inst/worker/worker.R
@@ -1,17 +1,15 @@
 # Worker class
 
-port <- as.integer(Sys.getenv("SPARKR_WORKER_PORT"))
-
-inputCon <- socketConnection(port = port, blocking = TRUE, open = "rb")
-outputCon <- socketConnection(port = port, blocking = TRUE, open = "wb")
-
+rLibDir <- Sys.getenv("SPARKR_RLIBDIR")
 # Set libPaths to include SparkR package as loadNamespace needs this
 # TODO: Figure out if we can avoid this by not loading any objects that require
 # SparkR namespace
-rLibDir <- readLines(inputCon, n = 1)
 .libPaths(c(rLibDir, .libPaths()))
-
 suppressPackageStartupMessages(library(SparkR))
+
+port <- as.integer(Sys.getenv("SPARKR_WORKER_PORT"))
+inputCon <- socketConnection(port = port, blocking = TRUE, open = "rb")
+outputCon <- socketConnection(port = port, blocking = TRUE, open = "wb")
 
 # read the index of the current partition inside the RDD
 splitIndex <- SparkR:::readInt(inputCon)

--- a/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
+++ b/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
@@ -1,7 +1,7 @@
 package edu.berkeley.cs.amplab.sparkr
 
 import java.io._
-import java.net.{ServerSocket}
+import java.net.{Socket, ServerSocket}
 import java.util.{Map => JMap}
 
 import scala.collection.JavaConversions._
@@ -36,10 +36,9 @@ private abstract class BaseRRDD[T: ClassTag, U: ClassTag](
     val serverSocket = new ServerSocket(0, 2)
     val listenPort = serverSocket.getLocalPort()
 
-    val pb = rWorkerProcessBuilder(listenPort)
-    pb.redirectErrorStream(true)  // redirect stderr into stdout
-    val proc = pb.start()
-    val errThread =  startStdoutThread(proc)
+    // The stdout/stderr is shared by multiple tasks, because we use one daemon
+    // to launch child process as worker.
+    val errThread = RRDD.createRWorker(rLibDir, listenPort)
 
     // We use two sockets to separate input and output, then it's easy to manage
     // the lifecycle of them to avoid deadlock.
@@ -54,7 +53,6 @@ private abstract class BaseRRDD[T: ClassTag, U: ClassTag](
     val outSocket = serverSocket.accept()
     val inputStream = new BufferedInputStream(outSocket.getInputStream)
     val dataStream = openDataStream(inputStream)
-
     serverSocket.close()
 
     try {
@@ -85,34 +83,6 @@ private abstract class BaseRRDD[T: ClassTag, U: ClassTag](
   }
 
   /**
-   * ProcessBuilder used to launch worker R processes.
-   */
-  private def rWorkerProcessBuilder(port: Int) = {
-    val rCommand = "Rscript"
-    val rOptions = "--vanilla"
-    val rExecScript = rLibDir + "/SparkR/worker/worker.R"
-    val pb = new ProcessBuilder(List(rCommand, rOptions, rExecScript))
-    // Unset the R_TESTS environment variable for workers.
-    // This is set by R CMD check as startup.Rs
-    // (http://svn.r-project.org/R/trunk/src/library/tools/R/testing.R)
-    // and confuses worker script which tries to load a non-existent file
-    pb.environment().put("R_TESTS", "")
-    pb.environment().put("SPARKR_WORKER_PORT", port.toString)
-    pb
-  }
-
-  /**
-   * Start a thread to print the process's stderr to ours
-   */
-  private def startStdoutThread(proc: Process): BufferedStreamThread = {
-    val BUFFER_SIZE = 100
-    val thread = new BufferedStreamThread(proc.getInputStream, "stdout reader for R", BUFFER_SIZE)
-    thread.setDaemon(true)
-    thread.start()
-    thread
-  }
-
-  /**
    * Start a thread to write RDD data to the R process.
    */
   private def startStdinThread[T](
@@ -128,9 +98,6 @@ private abstract class BaseRRDD[T: ClassTag, U: ClassTag](
       override def run() {
         try {
           SparkEnv.set(env)
-          val printOut = new PrintStream(stream)
-          printOut.println(rLibDir)
-
           val dataOut = new DataOutputStream(stream)
           dataOut.writeInt(splitIndex)
 
@@ -163,6 +130,7 @@ private abstract class BaseRRDD[T: ClassTag, U: ClassTag](
             dataOut.writeInt(1)
           }
 
+          val printOut = new PrintStream(stream)
           for (elem <- iter) {
             if (parentSerialized) {
               val elemArr = elem.asInstanceOf[Array[Byte]]
@@ -312,7 +280,7 @@ private class StringRRDD[T: ClassTag](
   lazy val asJavaRDD : JavaRDD[String] = JavaRDD.fromRDD(this)
 }
 
-private class BufferedStreamThread(
+private[sparkr] class BufferedStreamThread(
     in: InputStream,
     name: String,
     errBufferSize: Int) extends Thread(name) {
@@ -320,14 +288,16 @@ private class BufferedStreamThread(
   var lineIdx = 0
   override def run() {
     for (line <- Source.fromInputStream(in).getLines) {
-      lines(lineIdx) = line
-      lineIdx = (lineIdx + 1) % errBufferSize
+      synchronized {
+        lines(lineIdx) = line
+        lineIdx = (lineIdx + 1) % errBufferSize
+      }
       // TODO: user logger
       System.err.println(line)
     }
   }
 
-  def getLines(): String = {
+  def getLines(): String = synchronized {
     (0 until errBufferSize).filter { x =>
       lines((x + lineIdx) % errBufferSize) != null
     }.map { x =>
@@ -337,6 +307,16 @@ private class BufferedStreamThread(
 }
 
 object RRDD {
+
+  // Because forking processes from Java is expensive, we prefer to launch
+  // a single R daemon (daemon.R) and tell it to fork new workers for our tasks.
+  // This daemon currently only works on UNIX-based systems now, so we should
+  // also fall back to launching workers (worker.R) directly.
+  // TODO(davies): make it configurable
+  val useDaemon = !System.getProperty("os.name").startsWith("Windows")
+  private[this] var errThread: BufferedStreamThread = _
+  private[this] var daemonSocket: Socket = _
+  private[this] var daemonChannel: DataOutputStream = _
 
   def createSparkContext(
       master: String,
@@ -366,6 +346,61 @@ object RRDD {
       sparkConf.setExecutorEnv(name.asInstanceOf[String], value.asInstanceOf[String])
     }
     new JavaSparkContext(sparkConf)
+  }
+
+  /**
+   * Start a thread to print the process's stderr to ours
+   */
+  private def startStdoutThread(proc: Process): BufferedStreamThread = {
+    val BUFFER_SIZE = 100
+    val thread = new BufferedStreamThread(proc.getInputStream, "stdout reader for R", BUFFER_SIZE)
+    thread.setDaemon(true)
+    thread.start()
+    thread
+  }
+
+  def createRProcess(rLibDir: String, port: Int, script: String) = {
+    val rCommand = "Rscript"
+    val rOptions = "--vanilla"
+    val rExecScript = rLibDir + "/SparkR/worker/" + script
+    val pb = new ProcessBuilder(List(rCommand, rOptions, rExecScript))
+    // Unset the R_TESTS environment variable for workers.
+    // This is set by R CMD check as startup.Rs
+    // (http://svn.r-project.org/R/trunk/src/library/tools/R/testing.R)
+    // and confuses worker script which tries to load a non-existent file
+    pb.environment().put("R_TESTS", "")
+    pb.environment().put("SPARKR_RLIBDIR", rLibDir)
+    pb.environment().put("SPARKR_WORKER_PORT", port.toString)
+    pb.redirectErrorStream(true)  // redirect stderr into stdout
+    val proc = pb.start()
+    val errThread = startStdoutThread(proc)
+    errThread
+  }
+
+  /**
+   * ProcessBuilder used to launch worker R processes.
+   */
+  def createRWorker(rLibDir: String, port: Int) = {
+    if (useDaemon) {
+      synchronized {
+        if (daemonSocket == null) {
+          // we expect one connections
+          val serverSocket = new ServerSocket(0, 1)
+          val daemonPort = serverSocket.getLocalPort()
+          errThread = createRProcess(rLibDir, daemonPort, "daemon.R")
+          // the socket used to send out the input of task
+          serverSocket.setSoTimeout(10000)
+          daemonSocket = serverSocket.accept()
+          daemonChannel = new DataOutputStream(daemonSocket.getOutputStream)
+          serverSocket.close()
+        }
+        daemonChannel.writeInt(port)
+        daemonChannel.flush()
+        errThread
+      }
+    } else {
+      createRProcess(rLibDir, port, "worker.R")
+    }
   }
 
   /**

--- a/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
+++ b/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/RRDD.scala
@@ -189,7 +189,7 @@ private class PairwiseRRDD[T: ClassTag](
           val hashedKey = dataStream.readInt()
           val contentPairsLength = dataStream.readInt()
           val contentPairs = new Array[Byte](contentPairsLength)
-          dataStream.read(contentPairs, 0, contentPairsLength)
+          dataStream.readFully(contentPairs)
           (hashedKey, contentPairs)
         case _ => null   // End of input
       }
@@ -231,7 +231,7 @@ private class RRDD[T: ClassTag](
       length match {
         case length if length > 0 =>
           val obj = new Array[Byte](length)
-          dataStream.read(obj, 0, length)
+          dataStream.readFully(obj, 0, length)
           obj
         case _ => null
       }

--- a/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/SerDe.scala
+++ b/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/SerDe.scala
@@ -50,8 +50,7 @@ object SerDe {
   def readBytes(in: DataInputStream) = {
     val len = readInt(in)
     val out = new Array[Byte](len)
-    val bytesRead = in.read(out, 0, len)
-    assert(len == bytesRead)
+    val bytesRead = in.readFully(out)
     out
   }
 
@@ -66,7 +65,7 @@ object SerDe {
   def readString(in: DataInputStream) = {
     val len = in.readInt()
     val asciiBytes = new Array[Byte](len)
-    in.read(asciiBytes, 0, len)
+    in.readFully(asciiBytes)
     assert(asciiBytes(len - 1) == 0)
     val str = new String(asciiBytes.dropRight(1).map(_.toChar))
     str


### PR DESCRIPTION
The Spark executor could use lots of memory to cache some data, then it's very expensive to fork a R process (or easy to fail).

The solution is fork a lightweight daemon (in R) process in the beginning (when needed), call the daemon to launch R worker when needed.

This is only works in Linux/Mac, In Windows, it will still fork a R worker from JVM.

This also reduce the overhead to launch a task from about 350ms to 30ms (tested on Mac OS X 10.9)

TODO: improve failure handling. (delay it until we finalize the code for worker)