### PR TITLE
[SparkR-209] `join`, `sort`, `filter` methods for DataFrame

### DIFF
--- a/pkg/NAMESPACE
+++ b/pkg/NAMESPACE
@@ -88,16 +88,20 @@ exportClasses("DataFrame")
 exportMethods("columns",
               "distinct",
               "dtypes",
+              "filter",
               "head",
               "limit",
+              "orderBy",
               "names",
               "printSchema",
               "registerTempTable",
               "repartition",
               "sampleDF",
               "schema",
+              "sortDF",
               "select",
-              "toRDD")
+              "toRDD",
+              "where")
 
 exportClasses("Column")
 

--- a/pkg/R/column.R
+++ b/pkg/R/column.R
@@ -23,8 +23,6 @@ column <- function(jc) {
   new("Column", jc)
 }
 
-# TODO: change Dsl to functions once update spark-sql
-# A helper function to create a column from name
 col <- function(x) {
   column(callJStatic("org.apache.spark.sql.functions", "col", x))
 }

--- a/pkg/R/pairRDD.R
+++ b/pkg/R/pairRDD.R
@@ -601,12 +601,12 @@ setMethod("foldByKey",
 #' rdd2 <- parallelize(sc, list(list(1, 2), list(1, 3)))
 #' join(rdd1, rdd2, 2L) # list(list(1, list(1, 2)), list(1, list(1, 3))
 #'}
-setGeneric("join", function(x, y, numPartitions) { standardGeneric("join") })
+setGeneric("join", function(x, y, ...) { standardGeneric("join") })
 
 #' @rdname join-methods
 #' @aliases join,RDD,RDD-method
 setMethod("join",
-          signature(x = "RDD", y = "RDD", numPartitions = "integer"),
+          signature(x = "RDD", y = "RDD"),
           function(x, y, numPartitions) {
             xTagged <- lapply(x, function(i) { list(i[[1]], list(1L, i[[2]])) })
             yTagged <- lapply(y, function(i) { list(i[[1]], list(2L, i[[2]])) })
@@ -615,7 +615,7 @@ setMethod("join",
               joinTaggedList(v, list(FALSE, FALSE))
             }
             
-            joined <- flatMapValues(groupByKey(unionRDD(xTagged, yTagged), numPartitions), doJoin)
+            joined <- flatMapValues(groupByKey(unionRDD(xTagged, yTagged), numToInt(numPartitions)), doJoin)
           })
 
 #' Left outer join two RDDs

--- a/pkg/inst/tests/test_sparkSQL.R
+++ b/pkg/inst/tests/test_sparkSQL.R
@@ -282,34 +282,34 @@ test_that("filter() on a DataFrame", {
 })
 
 test_that("join() on a DataFrame", {
-df <- jsonFile(sqlCtx, jsonPath)
-
-mockLines2 <- c("{\"name\":\"Michael\", \"test\": \"yes\"}",
-                "{\"name\":\"Andy\",  \"test\": \"no\"}",
-                "{\"name\":\"Justin\", \"test\": \"yes\"}",
-                "{\"name\":\"Bob\", \"test\": \"yes\"}")
-jsonPath2 <- tempfile(pattern="sparkr-test", fileext=".tmp")
-writeLines(mockLines2, jsonPath2)
-df2 <- jsonFile(sqlCtx, jsonPath2)
-
-joined <- join(df, df2)
-expect_equal(names(joined), c("age", "name", "name", "test"))
-expect_true(count(joined) == 12)
-
-joined2 <- join(df, df2, df$name == df2$name)
-expect_equal(names(joined2), c("age", "name", "name", "test"))
-expect_true(count(joined2) == 3)
-
-joined3 <- join(df, df2, df$name == df2$name, "right_outer")
-expect_equal(names(joined3), c("age", "name", "name", "test"))
-expect_true(count(joined3) == 4)
-expect_true(is.na(collect(joined3)$age[4]))
-
-joined4 <- select(join(df, df2, df$name == df2$name, "outer"),
-                  alias(df$age + 5, "newAge"), df$name, df2$test)
-expect_equal(names(joined4), c("newAge", "name", "test"))
-expect_true(count(joined4) == 4)
-expect_true(first(joined4)$newAge == 24)
+  df <- jsonFile(sqlCtx, jsonPath)
+  
+  mockLines2 <- c("{\"name\":\"Michael\", \"test\": \"yes\"}",
+                  "{\"name\":\"Andy\",  \"test\": \"no\"}",
+                  "{\"name\":\"Justin\", \"test\": \"yes\"}",
+                  "{\"name\":\"Bob\", \"test\": \"yes\"}")
+  jsonPath2 <- tempfile(pattern="sparkr-test", fileext=".tmp")
+  writeLines(mockLines2, jsonPath2)
+  df2 <- jsonFile(sqlCtx, jsonPath2)
+  
+  joined <- join(df, df2)
+  expect_equal(names(joined), c("age", "name", "name", "test"))
+  expect_true(count(joined) == 12)
+  
+  joined2 <- join(df, df2, df$name == df2$name)
+  expect_equal(names(joined2), c("age", "name", "name", "test"))
+  expect_true(count(joined2) == 3)
+  
+  joined3 <- join(df, df2, df$name == df2$name, "right_outer")
+  expect_equal(names(joined3), c("age", "name", "name", "test"))
+  expect_true(count(joined3) == 4)
+  expect_true(is.na(collect(joined3)$age[4]))
+  
+  joined4 <- select(join(df, df2, df$name == df2$name, "outer"),
+                    alias(df$age + 5, "newAge"), df$name, df2$test)
+  expect_equal(names(joined4), c("newAge", "name", "test"))
+  expect_true(count(joined4) == 4)
+  expect_true(first(joined4)$newAge == 24)
 })
 
 unlink(jsonPath)


### PR DESCRIPTION
SQL-Like methods:
- `join`
- `sort`
- `orderBy`
- `filter`
- `where`