### PR TITLE
Remove print statement in SparkRBackendHandler

### DIFF
--- a/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/SparkRBackendHandler.scala
+++ b/pkg/src/src/main/scala/edu/berkeley/cs/amplab/sparkr/SparkRBackendHandler.scala
@@ -165,7 +165,6 @@ class SparkRBackendHandler(server: SparkRBackend)
         }
       }
       if (!parameterWrapperType.isInstance(args(i))) {
-        System.err.println(s"arg $i not match: expected type $parameterWrapperType, but got ${args(i).getClass()}")
         return false
       }
     }


### PR DESCRIPTION
This print statement is noisy for SQL methods which have multiple APIs
(like loadDF). We already have a better error message when no valid
methods are found

cc @davies 