### PR TITLE
Include utils before SparkR for `head` to work

### DIFF
--- a/sparkR
+++ b/sparkR
@@ -27,6 +27,7 @@ cat > /tmp/sparkR.profile << EOF
   projecHome <- Sys.getenv("PROJECT_HOME")
   Sys.setenv(NOAWT=1)
   .libPaths(c(paste(projecHome,"/lib", sep=""), .libPaths()))
+  require(utils)
   require(SparkR)
   sc <- sparkR.init(Sys.getenv("MASTER", unset = ""))
   assign("sc", sc, envir=.GlobalEnv)


### PR DESCRIPTION
Before this change calling `head` on a DataFrame would not
work from the sparkR script as utils would be loaded after SparkR
and placed ahead in the search list. This change requires utils to
be loaded before SparkR

To test this you can try something like the following with and without this change
```
./sparkR
>mockLines <- c("{\"name\":\"Michael\"}",
               "{\"name\":\"Andy\", \"age\":30}",
               "{\"name\":\"Justin\", \"age\":19}")
>jsonPath <- tempfile(pattern="sparkr-test", fileext=".tmp")
>writeLines(mockLines, jsonPath)
>df <- jsonFile(sqlCtx, jsonPath)
>head(df)
```

cc @davies 