### PR TITLE
[SPARKR-219] Clear broadcast variables when JVM is shutdown

### DIFF
--- a/pkg/R/broadcast.R
+++ b/pkg/R/broadcast.R
@@ -60,3 +60,10 @@ setBroadcastValue <- function(bcastId, value) {
   bcastIdStr <- as.character(bcastId)
   .broadcastValues[[bcastIdStr]] <- value
 }
+
+#' Helper function to clear the list of broadcast variables we know about
+#' Should be called when the SparkR JVM backend is shutdown
+clearBroadcastVariables <- function() {
+  bcasts <- ls(.broadcastNames)
+  rm(list = bcasts, envir = .broadcastNames)
+}

--- a/pkg/R/jobj.R
+++ b/pkg/R/jobj.R
@@ -8,6 +8,15 @@
 # List of object ids to be removed
 .toRemoveJobjs <- new.env(parent = emptyenv())
 
+# Check if jobj was created with the current SparkContext
+isValidJobj <- function(jobj) {
+  if (exists(".scStartTime", envir = .sparkREnv)) {
+    jobj$appId == get(".scStartTime", envir = .sparkREnv)
+  } else {
+    FALSE
+  }
+}
+
 getJobj <- function(objId) {
   newObj <- jobj(objId)
   if (exists(objId, .validJobjs)) {
@@ -27,6 +36,8 @@ jobj <- function(objId) {
   # finalizers for environments or external references pointers.
   obj <- structure(new.env(parent = emptyenv()), class = "jobj")
   obj$id <- objId
+  obj$appId <- get(".scStartTime", envir = .sparkREnv)
+
   # Register a finalizer to remove the Java object when this reference
   # is garbage collected in R
   reg.finalizer(obj, cleanup.jobj)

--- a/pkg/R/jobj.R
+++ b/pkg/R/jobj.R
@@ -58,14 +58,24 @@ print.jobj <- function(x, ...) {
 }
 
 cleanup.jobj <- function(jobj) {
-  objId <- jobj$id
-  .validJobjs[[objId]] <- .validJobjs[[objId]] - 1
+  if (isValidJobj(jobj)) {
+    objId <- jobj$id
+    .validJobjs[[objId]] <- .validJobjs[[objId]] - 1
 
-  if (.validJobjs[[objId]] == 0) {
-    rm(list = objId, envir = .validJobjs)
-    # NOTE: We cannot call removeJObject here as the finalizer may be run
-    # in the middle of another RPC. Thus we queue up this object Id to be removed
-    # and then run all the removeJObject when the next RPC is called.
-    .toRemoveJobjs[[objId]] <- 1
+    if (.validJobjs[[objId]] == 0) {
+      rm(list = objId, envir = .validJobjs)
+      # NOTE: We cannot call removeJObject here as the finalizer may be run
+      # in the middle of another RPC. Thus we queue up this object Id to be removed
+      # and then run all the removeJObject when the next RPC is called.
+      .toRemoveJobjs[[objId]] <- 1
+    }
   }
+}
+
+clearJobjs <- function() {
+  valid <- ls(.validJobjs)
+  rm(list = valid, envir = .validJobjs)
+
+  removeList <- ls(.toRemoveJobjs)
+  rm(list = removeList, envir = .toRemoveJobjs)
 }

--- a/pkg/R/serialize.R
+++ b/pkg/R/serialize.R
@@ -27,9 +27,16 @@ writeObject <- function(con, object, writeType = TRUE) {
          numeric = writeDouble(con, object),
          raw = writeRaw(con, object),
          list = writeList(con, object),
-         jobj = writeString(con, object$id),
+         jobj = writeJobj(con, object),
          environment = writeEnv(con, object),
          stop("Unsupported type for serialization"))
+}
+
+writeJobj <- function(con, value) {
+  if (!isValidJobj(value)) {
+    stop("invalid jobj ", value$id)
+  }
+  writeString(con, value$id)
 }
 
 writeString <- function(con, value) {

--- a/pkg/R/sparkR.R
+++ b/pkg/R/sparkR.R
@@ -36,7 +36,12 @@ sparkR.stop <- function(env = .sparkREnv) {
     # Also close the connection and remove it from our env
     conn <- get(".sparkRCon", envir = env)
     close(conn)
+    # Clear all broadcast variables we have
+    # as the jobj will not be valid if we restart the JVM
+    clearBroadcastVariables()
+
     rm(".sparkRCon", envir = env)
+    rm(".scStartTime", envir = env)
   }
 
   if (exists(".monitorConn", envir = env)) {
@@ -178,6 +183,10 @@ sparkR.init <- function(
 
   nonEmptyJars <- Filter(function(x) { x != "" }, jars)
   localJarPaths <- sapply(nonEmptyJars, function(j) { utils::URLencode(paste("file:", uriSep, j, sep = "")) })
+
+  # Set the start time to identify jobjs
+  # Seconds resolution is good enough for this purpose, so use ints
+  assign(".scStartTime", as.integer(Sys.time()), envir = .sparkREnv)
 
   assign(
     ".sparkRjsc",

--- a/pkg/R/sparkR.R
+++ b/pkg/R/sparkR.R
@@ -36,9 +36,6 @@ sparkR.stop <- function(env = .sparkREnv) {
     # Also close the connection and remove it from our env
     conn <- get(".sparkRCon", envir = env)
     close(conn)
-    # Clear all broadcast variables we have
-    # as the jobj will not be valid if we restart the JVM
-    clearBroadcastVariables()
 
     rm(".sparkRCon", envir = env)
     rm(".scStartTime", envir = env)
@@ -49,6 +46,13 @@ sparkR.stop <- function(env = .sparkREnv) {
     close(conn)
     rm(".monitorConn", envir = env)
   }
+
+  # Clear all broadcast variables we have
+  # as the jobj will not be valid if we restart the JVM
+  clearBroadcastVariables()
+
+  # Clear jobj maps
+  clearJobjs()
 }
 
 #' Initialize a new Spark Context.

--- a/pkg/R/sparkRBackend.R
+++ b/pkg/R/sparkRBackend.R
@@ -13,6 +13,10 @@ isInstanceOf <- function(jobj, className) {
 # from the SparkRBackend.
 callJMethod <- function(objId, methodName, ...) {
   stopifnot(class(objId) == "jobj")
+  if (!isValidJobj(objId)) {
+    stop("Invalid jobj ", objId$id,
+         ". If SparkR was restarted, Spark operations need to be re-executed.")
+  }
   invokeJava(isStatic = FALSE, objId$id, methodName, ...)
 }
 

--- a/pkg/inst/tests/test_context.R
+++ b/pkg/inst/tests/test_context.R
@@ -8,3 +8,26 @@ test_that("repeatedly starting and stopping SparkR", {
     sparkR.stop()
   }
 })
+
+test_that("rdd GC across sparkR.stop", {
+  sparkR.stop()
+  sc <- sparkR.init() # sc should get id 0
+  rdd1 <- parallelize(sc, 1:20, 2L) # rdd1 should get id 1
+  rdd2 <- parallelize(sc, 1:10, 2L) # rdd2 should get id 2
+  sparkR.stop()
+
+  sc <- sparkR.init() # sc should get id 0 again
+
+  # GC rdd1 before creating rdd3 and rdd2 after
+  rm(rdd1)
+  gc()
+
+  rdd3 <- parallelize(sc, 1:20, 2L) # rdd3 should get id 1 now
+  rdd4 <- parallelize(sc, 1:10, 2L) # rdd4 should get id 2 now
+
+  rm(rdd2)
+  gc()
+
+  count(rdd3)
+  count(rdd4)
+})

--- a/pkg/inst/tests/test_context.R
+++ b/pkg/inst/tests/test_context.R
@@ -1,0 +1,10 @@
+context("test functions in sparkR.R")
+
+test_that("repeatedly starting and stopping SparkR", {
+  for (i in 1:4) {
+    sc <- sparkR.init()
+    rdd <- parallelize(sc, 1:20, 2L)
+    expect_equal(count(rdd), 20)
+    sparkR.stop()
+  }
+})


### PR DESCRIPTION
This fixes the problem where unit tests could not shutdown SparkContext. Also to help users debug such problems associate a JVM id for each JVM reference we hold. The validity of this id is also checked before a JVM reference is passed to the backend.

cc @davies 