### PR TITLE
[SPARKR-224] The serialized flag in a PipelinedRDD is not set correctly.

### DIFF
--- a/pkg/inst/tests/test_binary_function.R
+++ b/pkg/inst/tests/test_binary_function.R
@@ -22,7 +22,13 @@ test_that("union on two RDDs", {
   actual <- collect(union.rdd)
   expect_equal(actual, c(as.list(nums), mockFile))
   expect_true(getSerializedMode(union.rdd) == "byte")
-  
+
+  rdd<- map(text.rdd, function(x) {x})
+  union.rdd <- unionRDD(rdd, text.rdd)
+  actual <- collect(union.rdd)
+  expect_equal(actual, as.list(c(mockFile, mockFile)))
+  expect_true(getSerializedMode(union.rdd) == "byte")
+
   unlink(fileName)
 })
 


### PR DESCRIPTION
The issue reported in https://sparkr.atlassian.net/browse/SPARKR-224 was fixed by https://sparkr.atlassian.net/browse/SPARKR-228. Here I add a new test case to unionRDD(), which helped to catch the issue.