### PR TITLE
added warning on new spark release

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
 
 <p><i>NOTE: As of April 2015, SparkR has been <a href="https://github.com/apache/spark/pull/5096">officially merged</a> into Apache Spark and is shipping in an upcoming release (1.4) due early summer 2015.</i></p>
 
+<p><i>NOTE: The API from the upcoming Spark release (1.4) will <b>not</b> have the same API as described here. Initial support for Spark in R be focussed on high level operations instead of low level ETL. This may change in the (1.5) version.</i></p>
+
 <h2>
 <a name="features" class="anchor" href="#features"><span class="octicon octicon-link"></span></a>Features</h2>
 

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
 <p>SparkR is an R package that provides a light-weight frontend to use Apache Spark from R. SparkR exposes the Spark API through the <code>RDD</code> class and allows users to interactively run jobs from the R shell on a cluster.</p>
 
-<p><i>NOTE: As of April 2015, SparkR has been <a href="https://github.com/apache/spark/pull/5096">officially merged</a> into Apache Spark and is shipping in an upcoming release (1.4) due early summer 2015.</i></p>
+<p><i>NOTE: As of April 2015, SparkR has been <a href="https://github.com/apache/spark/pull/5096">officially merged</a> into Apache Spark and is shipping in an upcoming release (1.4) due early summer 2015. You can contribute and follow SparkR developments on the Apache Spark mailing lists and [issue tracker](https://issues.apache.org/jira/browse/SPARK/component/12325400).</i></p>
 
 <p><i>NOTE: The API from the upcoming Spark release (1.4) will <b>not</b> have the same API as described here. Initial support for Spark in R be focussed on high level operations instead of low level ETL. This may change in the (1.5) version.</i></p>
 

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
 <p>SparkR is an R package that provides a light-weight frontend to use Apache Spark from R. SparkR exposes the Spark API through the <code>RDD</code> class and allows users to interactively run jobs from the R shell on a cluster.</p>
 
-<p><i>NOTE: As of April 2015, SparkR has been <a href="https://github.com/apache/spark/pull/5096">officially merged</a> into Apache Spark and is shipping in an upcoming release (1.4) due early summer 2015. You can contribute and follow SparkR developments on the Apache Spark mailing lists and [issue tracker](https://issues.apache.org/jira/browse/SPARK/component/12325400).</i></p>
+<p><i>NOTE: As of April 2015, SparkR has been <a href="https://github.com/apache/spark/pull/5096">officially merged</a> into Apache Spark and is shipping in an upcoming release (1.4) due early summer 2015. You can contribute and follow SparkR developments on the Apache Spark mailing lists and <a href='https://issues.apache.org/jira/browse/SPARK/component/12325400'>issue tracker</a>.</i></p>
 
 <p><i>NOTE: The API from the upcoming Spark release (1.4) will <b>not</b> have the same API as described here. Initial support for Spark in R be focussed on high level operations instead of low level ETL. This may change in the (1.5) version.</i></p>
 


### PR DESCRIPTION
We might want to link to the JIRA, but this comment should at least make new developers aware that things are changing. The new github repo at apache Spark should contain any new information as it becomes available. Linking to the JIRA conversation doesn't seem necessary. 