### PR TITLE
warning on spark 1.4 in readme.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ R.
 
 *NOTE: As of April 2015, SparkR has been [merged](https://github.com/apache/spark/pull/5096) into Apache Spark and is shipping in an upcoming release (1.4) due early summer 2015. This repo currently targets users using released versions of Spark. __This repo no longer accepts new pull requests, and they should now be submitted to [apache/spark](https://github.com/apache/spark); see [here](https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark) for some instructions.__*
 
+*NOTE: The API from the upcoming Spark release (1.4) will <b>not</b> have the same API as the on in this github repo. Initial support for Spark in R be focussed on high level operations instead of low level ETL. This may change in the (1.5) version.*
 
 ## Installing SparkR
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ R.
 
 *NOTE: As of April 2015, SparkR has been [merged](https://github.com/apache/spark/pull/5096) into Apache Spark and is shipping in an upcoming release (1.4) due early summer 2015. This repo currently targets users using released versions of Spark. __This repo no longer accepts new pull requests, and they should now be submitted to [apache/spark](https://github.com/apache/spark); see [here](https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark) for some instructions.__*
 
-*NOTE: The API from the upcoming Spark release (1.4) will <b>not</b> have the same API as described by this github repo. Initial support for Spark in R be focussed on high level operations instead of low level ETL. This may change in the (1.5) version.*
+*NOTE: The API from the upcoming Spark release (1.4) will <b>not</b> have the same API as described by this github repo. Initial support for Spark in R be focussed on high level operations instead of low level ETL. This may change in the (1.5) version. You can contribute and follow SparkR developments on the Apache Spark mailing lists and [issue tracker](https://issues.apache.org/jira/browse/SPARK/component/12325400).*
 
 ## Installing SparkR
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ R.
 
 *NOTE: As of April 2015, SparkR has been [merged](https://github.com/apache/spark/pull/5096) into Apache Spark and is shipping in an upcoming release (1.4) due early summer 2015. This repo currently targets users using released versions of Spark. __This repo no longer accepts new pull requests, and they should now be submitted to [apache/spark](https://github.com/apache/spark); see [here](https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark) for some instructions.__*
 
-*NOTE: The API from the upcoming Spark release (1.4) will <b>not</b> have the same API as the on in this github repo. Initial support for Spark in R be focussed on high level operations instead of low level ETL. This may change in the (1.5) version.*
+*NOTE: The API from the upcoming Spark release (1.4) will <b>not</b> have the same API as described by this github repo. Initial support for Spark in R be focussed on high level operations instead of low level ETL. This may change in the (1.5) version.*
 
 ## Installing SparkR
 


### PR DESCRIPTION
a similar pull request was made for the github pages. i've added the same warning to the readme.md file as well. some people (like me) skip the website and go straight for the github. might be fair to add a warning here as well.